### PR TITLE
nushell: change deprecated `--ignore-errors` flag to `--optional`

### DIFF
--- a/src/shells.rs
+++ b/src/shells.rs
@@ -260,7 +260,7 @@ $env.config.hooks.pre_prompt = (
                 if "h" in $m {
                     # no in-scope eval, so run the hook in a child nu and diff
                     # its env before/after to propagate vars it set or unset.
-                    let prog = ("let __pre = $env\n" + $m.h + "\nlet __post = $env\nlet __set = ($__post | transpose k v | where {|r| ($r.v | describe) == \"string\" and $r.k not-in [PWD OLDPWD] and (($__pre | get -i $r.k) != $r.v)} | reduce -f {} {|r, a| $a | upsert $r.k $r.v}); {set: $__set, unset: ($__pre | columns | where {|k| $k not-in ($__post | columns)})} | to json")
+                    let prog = ("let __pre = $env\n" + $m.h + "\nlet __post = $env\nlet __set = ($__post | transpose k v | where {|r| ($r.v | describe) == \"string\" and $r.k not-in [PWD OLDPWD] and (($__pre | get --optional $r.k) != $r.v)} | reduce -f {} {|r, a| $a | upsert $r.k $r.v}); {set: $__set, unset: ($__pre | columns | where {|k| $k not-in ($__post | columns)})} | to json")
                     let d = (^$nu_exe --no-config-file --commands $prog | from json)
                     load-env $d.set
                     for k in $d.unset { hide-env --ignore-errors $k }


### PR DESCRIPTION
Deprecated in Nushell [v0.106.0](https://www.nushell.sh/blog/2025-07-23-nushell_0_106_0.html#ignore-errors-i-renamed-to-optional-o-toc)

Otherwise, this is shown every time I change directory in a project where I'm using cade:
```
Warning: nu::parser::deprecated

  ! Flag deprecated.
   ,-[source:4:129]
 3 | let __post = $env
 4 | let __set = ($__post | transpose k v | where {|r| ($r.v | describe) == "string" and $r.k not-in [PWD OLDPWD] and (($__pre | get -i $r.k) != $r.v)} | reduce -f {} {|r, a| $a | upsert $r.k $r.v}); {set: $__set, unset: ($__pre | columns | where {|k| $k not-in ($__post | columns)})} | to json
   :                                                                                                                                 ^|
   :                                                                                                                                  `-- get --ignore-errors was deprecated in 0.106.0 and will be removed in a future release.
   `----
  help: This flag has been renamed to `--optional (-o)` to better reflect its behavior.
```