### PR TITLE
nushell: split hooks and env between stdout/err

### DIFF
--- a/src/shells.rs
+++ b/src/shells.rs
@@ -258,10 +258,11 @@ $env.config.hooks.pre_prompt = (
                 if "s" in $m { load-env $m.s }
                 if "u" in $m { hide-env --ignore-errors $m.u }
                 if "h" in $m {
-                    # no in-scope eval, so run the hook in a child nu and diff
-                    # its env before/after to propagate vars it set or unset.
-                    let prog = ("let __pre = $env\n" + $m.h + "\nlet __post = $env\nlet __set = ($__post | transpose k v | where {|r| ($r.v | describe) == \"string\" and $r.k not-in [PWD OLDPWD] and (($__pre | get -i $r.k) != $r.v)} | reduce -f {} {|r, a| $a | upsert $r.k $r.v}); {set: $__set, unset: ($__pre | columns | where {|k| $k not-in ($__post | columns)})} | to json")
-                    let d = (^$nu_exe --no-config-file --commands $prog | from json)
+                    # run hook in a child nu, detect env changes by diffing
+                    # pre/post $env in-process. JSON diff goes to stderr via
+                    # print --stderr so hook stdout can't contaminate it.
+                    let prog = ("let __pre = $env\n" + $m.h + "\nlet __post = $env\nlet __set = ($__post | transpose k v | where {|r| ($r.v | describe) == \"string\" and $r.k not-in [PWD OLDPWD] and (($__pre | get --optional $r.k) != $r.v)} | reduce -f {} {|r, a| $a | upsert $r.k $r.v}); {set: $__set, unset: ($__pre | columns | where {|k| $k not-in ($__post | columns)})} | to json | print --stderr")
+                    let d = (^$nu_exe --no-config-file --commands $prog err>| from json)
                     load-env $d.set
                     for k in $d.unset { hide-env --ignore-errors $k }
                 }


### PR DESCRIPTION
Hooks handled via stdout and env handled via stderr.

Error:
```
 cd cade
cade: loaded /home/jam/projects/cade.
Error: nu::shell::error

  × Error while parsing JSON text
    ╭─[/nix/store/yaiwb1152gdsdnmrajzg8k2xpqqpcqdx-cade-hook-nu:18:31]
 17 │                     let prog = ("let __pre = $env\n" + $m.h + "\nlet __post = $env\nlet __set = ($__post | transpose k v | where
 18 │                     let d = (^$nu_exe --no-config-file --commands $prog | from json)
    ·                               ───┬───
    ·                                  ╰── error parsing JSON text
 19 │                     load-env $d.set
    ╰────
  ╰─▶ nu::shell::outsidespan

        × Error while parsing JSON text
         ╭─[2:1]
       1 │ hello
       2 │ {
         · ▲
         · ╰── "trailing characters" at line 2 column 1
       3 │   "set": {},
         ╰────
```

With `hook load print "hello"` in our config file. Setting env vars like `ENV=var` also seemed to be affected it.

After this change, this cade file works perfectly:
```
load flake
hook load print "hello"
TESTENV=abcdef
```
Output:
```nu
 cd cade
cade: loaded /home/jam/projects/cade.
hello
 $env.TESTENV
abcdef
```

I think this is the simplest way to fix without using tmp files and such.

This change also fixes the issue in #1 too. So you don't need both.

Sorry about the horrible diff, maybe such strings should be nicely formatted? I can do it if you want.