### PR TITLE
add json output + direnv shims

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,13 @@ programs.cade = {
   enableFishIntegration = true;  # default; needs programs.fish.enable
   verbosity = "normal";          # null, quiet, normal, vars, trace
   longRunningWarningMs = 5000;   # null, or a positive integer
+  direnvCompat = false;          # false/"none", or true/"bash" for the shim
 };
 ```
+
+`direnvCompat` installs a cade-backed `direnv` on `PATH` (see
+[direnv compatibility](#direnv-compatibility)). it collides with a real direnv
+in `environment.systemPackages`, so install only one.
 
 setting `verbosity` or `longRunningWarningMs` makes the module generate a TOML
 config file and pass it to cade with `--config`. alternatively, set
@@ -260,6 +265,21 @@ an `.envrc` is picked up two ways:
 
 anything cade can't faithfully reproduce (shell expansion, conditionals,
 `layout`, `source_up`, functions, unknown flags) is skipped with a warning.
+
+### the direnv shim
+
+the reverse is also covered: a `direnv` shim maps the direnv cli tools rely on
+(chiefly `direnv export json`) onto cade, so direnv-aware tooling drives cade
+unmodified. `export`, `hook`, `allow`/`deny`, and `status` are mapped too.
+
+enable it in the module with `programs.cade.direnvCompat = true;`, or build it
+from the flake (bash and nushell builds exist and behave the same):
+
+```sh
+nix build .#direnv-compat-bash   # produces bin/direnv
+```
+
+put it on `PATH` in place of a real direnv. it requires cade installed too.
 
 ## example
 

--- a/flake.nix
+++ b/flake.nix
@@ -29,10 +29,21 @@
           };
         };
       });
-      packages = forAllSystems (pkgs: {
-        cade = pkgs.callPackage ./nix/package.nix { };
-        default = self.packages.${pkgs.stdenv.hostPlatform.system}.cade;
-      });
+      packages = forAllSystems (
+        pkgs:
+        let
+          cade = pkgs.callPackage ./nix/package.nix { };
+          direnvShims = pkgs.callPackage ./nix/direnv-compat.nix { inherit cade; };
+        in
+        {
+          inherit cade;
+          default = cade;
+          # cade-backed `direnv` binaries; also wired into the module behind
+          # programs.cade.direnvCompat
+          direnv-compat-bash = direnvShims.bash;
+          direnv-compat-nu = direnvShims.nu;
+        }
+      );
 
       # System modules add the cade package and wire its shell hooks into
       # interactive bash/zsh/fish. The same module works on both platforms.

--- a/nix/direnv-compat.bash
+++ b/nix/direnv-compat.bash
@@ -1,0 +1,72 @@
+#!@bash@/bin/bash
+# direnv shim: maps the direnv cli surface tools rely on onto cade calls.
+# drop on PATH as `direnv`. unknown subcommands are silent no-ops
+set -u
+
+cade=@cade@
+
+cmd=${1:-}
+target=${2:-}
+
+target_dir() {
+  local operand=${1:-}
+
+  if [ -z "$operand" ]; then
+    printf '.\n'
+  elif [ -d "$operand" ]; then
+    printf '%s\n' "$operand"
+  else
+    dirname -- "$operand"
+  fi
+}
+
+run_in_target_dir() {
+  local action=$1
+  local operand=${2:-}
+  local dir
+
+  dir=$(target_dir "$operand") || return
+  (
+    cd -- "$dir" && "$cade" "$action"
+  )
+}
+
+case $cmd in
+  export)
+    case ${target:-bash} in
+      json)
+        out=$("$cade" reload --shell json)
+        status=$?
+        if [ "$status" -ne 0 ]; then
+          [ -z "$out" ] || printf '%s\n' "$out"
+          exit "$status"
+        fi
+        [ -n "$out" ] || out='{}'
+        printf '%s\n' "$out"
+        ;;
+      bash | zsh | fish | nushell | nu)
+        "$cade" reload --shell "${target:-bash}"
+        ;;
+    esac
+    ;;
+  hook)
+    "$cade" hook "${target:-bash}"
+    ;;
+  allow | permit | grant)
+    run_in_target_dir allow "$target"
+    ;;
+  deny | block | revoke)
+    run_in_target_dir disallow "$target"
+    ;;
+  status)
+    if [ "${target:-}" = "--json" ]; then
+      printf 'direnv shim: status --json is unsupported\n' >&2
+      exit 1
+    fi
+    "$cade" status
+    ;;
+  version)
+    # satisfy version-gated callers
+    echo "2.34.0"
+    ;;
+esac

--- a/nix/direnv-compat.nix
+++ b/nix/direnv-compat.nix
@@ -1,0 +1,31 @@
+# builds the `direnv` shims from the scripts beside this file, substituting
+# store paths for the @placeholders@. both just relay `cade reload`, so they
+# behave identically; pick by which interpreter you'd rather depend on
+{
+  lib,
+  writeScriptBin,
+  bash,
+  nushell,
+  cade,
+}:
+let
+  cadeExe = lib.getExe cade;
+  fromTemplate =
+    replacements: file:
+    writeScriptBin "direnv" (
+      builtins.replaceStrings (builtins.attrNames replacements) (builtins.attrValues replacements) (
+        builtins.readFile file
+      )
+    );
+in
+{
+  bash = fromTemplate {
+    "@bash@" = "${bash}";
+    "@cade@" = cadeExe;
+  } ./direnv-compat.bash;
+
+  nu = fromTemplate {
+    "@nu@" = "${nushell}";
+    "@cade@" = cadeExe;
+  } ./direnv-compat.nu;
+}

--- a/nix/direnv-compat.nu
+++ b/nix/direnv-compat.nu
@@ -1,0 +1,54 @@
+#!@nu@/bin/nu
+# direnv shim, nushell flavour. behaviour matches direnv-compat.bash: relay
+# cade's own json/shell output so no json is serialised here
+
+def target-dir [target: string] {
+  if ($target | is-empty) {
+    "."
+  } else {
+    let expanded = ($target | path expand)
+    if (($expanded | path type) == "dir") {
+      $expanded
+    } else {
+      $expanded | path dirname
+    }
+  }
+}
+
+def --wrapped main [cmd?: string = "", target?: string = "", ...rest: string] {
+  match $cmd {
+    "export" => {
+      let want = (if ($target | is-empty) { "bash" } else { $target })
+      match $want {
+        "json" => {
+          let out = (^@cade@ reload --shell json)
+          if ($out | is-empty) { "{}" } else { $out }
+        }
+        "bash" | "zsh" | "fish" | "nushell" | "nu" => {
+          ^@cade@ reload --shell $want
+        }
+        _ => {}
+      }
+    }
+    "hook" => {
+      ^@cade@ hook (if ($target | is-empty) { "bash" } else { $target })
+    }
+    "allow" | "permit" | "grant" => {
+      cd (target-dir $target)
+      ^@cade@ allow
+    }
+    "deny" | "block" | "revoke" => {
+      cd (target-dir $target)
+      ^@cade@ disallow
+    }
+    "status" => {
+      if $target == "--json" {
+        print -e "direnv shim: status --json is unsupported"
+        exit 1
+      }
+      ^@cade@ status
+    }
+    "version" => { print "2.34.0" }
+    _ => {}
+  }
+}

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -32,6 +32,16 @@ let
     ]
   ));
   snippets = import ./snippets.nix { cade = cadeCmd; };
+
+  # normalise the bool/enum direnvCompat to "none" | "bash" | "nu"
+  direnvChoice =
+    if cfg.direnvCompat == true then
+      "bash"
+    else if cfg.direnvCompat == false then
+      "none"
+    else
+      cfg.direnvCompat;
+  direnvShims = pkgs.callPackage "${self}/nix/direnv-compat.nix" { cade = cfg.package; };
 in
 {
   options.programs.cade = {
@@ -85,6 +95,23 @@ in
       description = "Strict TOML config path passed to cade with --config instead of generating one from module options.";
     };
 
+    direnvCompat = lib.mkOption {
+      type = lib.types.either lib.types.bool (lib.types.enum [
+        "none"
+        "bash"
+        "nu"
+      ]);
+      default = false;
+      example = true;
+      description = ''
+        install a cade-backed `direnv` on PATH so direnv-aware tools drive cade.
+        `true`/`"bash"` install the bash shim, `"nu"` the nushell one (they
+        behave identically), `false`/`"none"` install nothing. provides a
+        `direnv` binary, so it collides with a real direnv in
+        environment.systemPackages
+      '';
+    };
+
     # Nushell, Elvish, and Murex have no system-level interactive-init hook on
     # NixOS or nix-darwin, so the module can't wire them automatically. These
     # read-only snippets expose the exact init lines for each, so you can drop
@@ -123,7 +150,10 @@ in
       }
     ];
 
-    environment.systemPackages = [ cfg.package ];
+    environment.systemPackages =
+      [ cfg.package ]
+      ++ lib.optional (direnvChoice == "bash") direnvShims.bash
+      ++ lib.optional (direnvChoice == "nu") direnvShims.nu;
 
     # bash and zsh evaluate the hook; the shell flag must be enabled by the user
     # (programs.zsh.enable / shell installed) for the init file to be sourced.

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,18 +55,21 @@ fn try_main() -> Result<()> {
             let output = shell_name.get_output();
             cade.do_activation(output.as_ref(), Announce::Loaded)
                 .context("activate cade environment")?;
+            print!("{}", output.finish());
         }
         Exit { shell } => {
             let shell_name: ShellName = shell.parse().map_err(|e: String| anyhow::anyhow!(e))?;
             let output = shell_name.get_output();
             cade.do_restore(output.as_ref(), true, true)
                 .context("deactivate cade environment")?;
+            print!("{}", output.finish());
         }
         Reload { shell } => {
             let shell_name: ShellName = shell.parse().map_err(|e: String| anyhow::anyhow!(e))?;
             let output = shell_name.get_output();
             cade.do_reload(output.as_ref())
                 .context("reload cade environment")?;
+            print!("{}", output.finish());
         }
         Allow => cade.allow_here(true)?,
         Disallow => cade.allow_here(false)?,

--- a/src/shells.rs
+++ b/src/shells.rs
@@ -1,4 +1,6 @@
 use crate::verbosity::{self, Verbosity};
+use std::cell::RefCell;
+use std::collections::BTreeMap;
 use std::fmt;
 use std::str::FromStr;
 
@@ -7,6 +9,11 @@ pub trait ShellOutput {
     fn unset_env(&self, key: &str) -> String;
     fn emit_hook(&self, command: &str) -> String;
     fn hook_init(&self, cade_exe: &str, cade_args: &[String]) -> String;
+    // buffered targets (json) collect everything and emit here once all
+    // set/unset calls are done; line shells emit inline and return nothing
+    fn finish(&self) -> String {
+        String::new()
+    }
 }
 
 /// A valid env var identifier. Prevents breakout
@@ -62,6 +69,8 @@ pub enum ShellName {
     Nushell,
     Elvish,
     Murex,
+    // not a shell: a direnv-compatible env diff for tools to consume
+    Json,
 }
 
 impl fmt::Display for ShellName {
@@ -73,6 +82,7 @@ impl fmt::Display for ShellName {
             ShellName::Nushell => write!(f, "nushell"),
             ShellName::Elvish => write!(f, "elvish"),
             ShellName::Murex => write!(f, "murex"),
+            ShellName::Json => write!(f, "json"),
         }
     }
 }
@@ -87,6 +97,7 @@ impl FromStr for ShellName {
             "nushell" | "nu" => Ok(ShellName::Nushell),
             "elvish" => Ok(ShellName::Elvish),
             "murex" => Ok(ShellName::Murex),
+            "json" => Ok(ShellName::Json),
             _ => Err(format!("unknown shell: {s}")),
         }
     }
@@ -101,6 +112,7 @@ impl ShellName {
             ShellName::Nushell => Box::new(Nushell),
             ShellName::Elvish => Box::new(Elvish),
             ShellName::Murex => Box::new(Murex),
+            ShellName::Json => Box::new(Json::new()),
         }
     }
 }
@@ -354,6 +366,54 @@ impl ShellOutput for Murex {
     }
 }
 
+// --- Json ---
+
+// a direnv-compatible env diff: one json object, set keys to their value and
+// unset keys to null. buffered so serde owns the escaping; cade uses U+001F as
+// a value separator, and hand-rolled json (e.g. nushell's `to json`) emits it
+// raw, which is invalid
+pub struct Json {
+    changes: RefCell<BTreeMap<String, Option<String>>>,
+}
+
+impl Json {
+    pub fn new() -> Self {
+        Json {
+            changes: RefCell::new(BTreeMap::new()),
+        }
+    }
+}
+
+impl ShellOutput for Json {
+    fn set_env(&self, key: &str, value: &str) -> String {
+        if is_valid_key(key) {
+            self.changes
+                .borrow_mut()
+                .insert(key.to_string(), Some(value.to_string()));
+        }
+        String::new()
+    }
+    fn unset_env(&self, key: &str) -> String {
+        if is_valid_key(key) {
+            self.changes.borrow_mut().insert(key.to_string(), None);
+        }
+        String::new()
+    }
+    // hooks have no representation in a static env diff (direnv drops them too)
+    fn emit_hook(&self, _command: &str) -> String {
+        String::new()
+    }
+    fn hook_init(&self, _cade_exe: &str, _cade_args: &[String]) -> String {
+        String::new()
+    }
+    fn finish(&self) -> String {
+        format!(
+            "{}\n",
+            serde_json::to_string(&*self.changes.borrow()).unwrap_or_else(|_| "{}".to_string())
+        )
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -446,5 +506,18 @@ mod tests {
         // a JSON directive parsed with `from json`, never run as nu code
         let v: serde_json::Value = serde_json::from_str(out.trim()).unwrap();
         assert_eq!(v["s"]["X"], "$(id)\"x");
+    }
+
+    #[test]
+    fn json_buffers_one_valid_object_escaping_separators() {
+        let json = Json::new();
+        // set_env/unset_env emit nothing inline; finish() emits the whole object
+        assert_eq!(json.set_env("A", "x\x1fy"), "");
+        assert_eq!(json.unset_env("B"), "");
+        let out = json.finish();
+        // strict parse proves the U+001F separator was escaped, not emitted raw
+        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(v["A"], "x\x1fy");
+        assert!(v["B"].is_null());
     }
 }


### PR DESCRIPTION
this enables applications that want to call direnv directly to be shimmed through cade and receive a similar output.
mainly done for the `export json` command, but others are thrown in just in case.
the shims are exposed as package outputs, or used in the nixosModule as `programs.cade.direnvCompat`, which is a union of bool and enum that takes `false | true | "none" | "bash" | "nu"` (`true` == "bash")