### PR TITLE
direnv shim, part II

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,15 @@ programs.cade = {
   enableFishIntegration = true;  # default; needs programs.fish.enable
   verbosity = "normal";          # null, quiet, normal, vars, trace
   longRunningWarningMs = 5000;   # null, or a positive integer
+  direnvCompat = false;          # true installs the direnv shim for tools
 };
 ```
+
+`direnvCompat` installs a cade-backed `direnv` on `PATH` for editors and other
+direnv-aware tools (see [direnv compatibility](#direnv-compatibility)). it is
+not the shell integration path; interactive shells should use `cade hook
+<shell>`. the shim collides with a real direnv in `environment.systemPackages`,
+so install only one.
 
 setting `verbosity` or `longRunningWarningMs` makes the module generate a TOML
 config file and pass it to cade with `--config`. alternatively, set
@@ -114,14 +121,15 @@ eval (cade hook elvish | slurp)
 cade hook murex -> source
 ```
 
-for nix users with declarative configs, you may want to dump the hook at build time and source it. 
+for nix users with declarative configs, you may want to dump the hook at build
+time and source it.
 nushell example:
 
 ```nix
 source ${
   (pkgs.runCommand "cade.nu" { } ''${lib.getExe (getFlakePkg inputs.cade)} hook nushell >> "$out"'')
 }
-````
+```
 
 ## usage
 
@@ -260,6 +268,40 @@ an `.envrc` is picked up two ways:
 
 anything cade can't faithfully reproduce (shell expansion, conditionals,
 `layout`, `source_up`, functions, unknown flags) is skipped with a warning.
+
+for Nix dev shells, cade captures the final process environment from
+`nix develop --command` rather than parsing `nix print-dev-env --json`. the JSON
+form misses setup done by bash while entering the shell, including `shellHook`
+and devshell PATH changes. the shell-script form of `print-dev-env` can express
+that setup, but would require cade to evaluate bash itself; `nix develop` keeps
+that responsibility inside Nix.
+
+### the direnv shim
+
+the reverse is also covered: a `direnv` shim maps the direnv cli tools rely on
+(chiefly `direnv export json`) onto cade, so direnv-aware tooling such as
+editors can drive cade unmodified. this shim is only for tool compatibility;
+use `cade hook <shell>` for interactive shells and `cade allow` / `cade
+disallow` for trust decisions. only `export json` is mapped. shell hooks and
+shell export formats are harmless no-ops so login shell environment capture
+keeps working, but they do not activate cade. other direnv commands fail as
+unsupported. the shim maps JSON export to cade's hidden direnv-compatible JSON
+endpoint; `json` is an output format, not a shell accepted by `--shell`.
+
+the JSON exporter carries minimal `DIRENV_DIFF` state containing only previous
+values for variables cade changed. that state lets repeated exports, directory
+leave, and re-enter restore the editor environment without growing `PATH` or
+leaking a full ambient environment snapshot.
+
+enable it in the module with `programs.cade.direnvCompat = true;`, or build it
+from the flake:
+
+```sh
+nix build .#direnv-compat   # produces bin/direnv
+```
+
+put it on `PATH` in place of a real direnv. the packaged shim embeds the cade
+store path, so it does not need to find `cade` through `PATH`.
 
 ## example
 

--- a/flake.nix
+++ b/flake.nix
@@ -37,10 +37,20 @@
           };
         };
       });
-      packages = forAllSystems (pkgs: {
-        cade = pkgs.callPackage ./nix/package.nix { };
-        default = self.packages.${pkgs.stdenv.hostPlatform.system}.cade;
-      });
+      packages = forAllSystems (
+        pkgs:
+        let
+          cade = pkgs.callPackage ./nix/package.nix { };
+          direnvCompat = pkgs.callPackage ./nix/direnv-compat.nix { inherit cade; };
+        in
+        {
+          inherit cade;
+          default = cade;
+          # cade-backed `direnv` binary; also wired into the module behind
+          # programs.cade.direnvCompat
+          direnv-compat = direnvCompat;
+        }
+      );
 
       # System modules add the cade package and wire its shell hooks into
       # interactive bash/zsh/fish. The same module works on both platforms.

--- a/nix/direnv-compat.bash
+++ b/nix/direnv-compat.bash
@@ -1,0 +1,32 @@
+#!@bash@/bin/bash
+# Minimal direnv shim for tools that call `direnv export json`.
+# Shell hook/export probes are no-ops so login-shell env capture keeps working.
+set -eu
+
+cade=@cade@
+
+cmd=${1:-}
+target=${2:-}
+
+case $cmd in
+  export)
+    case ${target:-bash} in
+      json)
+        "$cade" export json
+        ;;
+      bash | zsh | fish | nushell | nu)
+        ;;
+      *)
+        printf 'direnv shim: unsupported export target: %s\n' "$target" >&2
+        exit 1
+        ;;
+    esac
+    ;;
+  hook)
+    ;;
+  *)
+    printf 'direnv shim: unsupported command: %s\n' "${cmd:-<empty>}" >&2
+    exit 1
+    ;;
+esac
+exit 0

--- a/nix/direnv-compat.nix
+++ b/nix/direnv-compat.nix
@@ -1,0 +1,16 @@
+# Builds the cade-backed `direnv` shim from the script beside this file,
+# substituting store paths for the @placeholders@.
+{
+  lib,
+  writeScriptBin,
+  bash,
+  cade,
+}:
+let
+  cadeExe = lib.getExe cade;
+in
+writeScriptBin "direnv" (
+  builtins.replaceStrings [ "@bash@" "@cade@" ] [ "${bash}" cadeExe ] (
+    builtins.readFile ./direnv-compat.bash
+  )
+)

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -32,6 +32,7 @@ let
     ]
   ));
   snippets = import ./snippets.nix { cade = cadeCmd; };
+  direnvShim = pkgs.callPackage "${self}/nix/direnv-compat.nix" { cade = cfg.package; };
 in
 {
   options.programs.cade = {
@@ -85,6 +86,18 @@ in
       description = "Strict TOML config path passed to cade with --config instead of generating one from module options.";
     };
 
+    direnvCompat = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      example = true;
+      description = ''
+        Install a cade-backed `direnv` executable on PATH for editor and tool
+        compatibility. This is not the shell integration path; interactive
+        shells should use cade's native hook snippets. The shim collides with a
+        real direnv in environment.systemPackages, so install only one.
+      '';
+    };
+
     # Nushell, Elvish, and Murex have no system-level interactive-init hook on
     # NixOS or nix-darwin, so the module can't wire them automatically. These
     # read-only snippets expose the exact init lines for each, so you can drop
@@ -123,7 +136,7 @@ in
       }
     ];
 
-    environment.systemPackages = [ cfg.package ];
+    environment.systemPackages = [ cfg.package ] ++ lib.optional cfg.direnvCompat direnvShim;
 
     # bash and zsh evaluate the hook; the shell flag must be enabled by the user
     # (programs.zsh.enable / shell installed) for the init file to be sourced.

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -15,6 +15,7 @@ rustPlatform.buildRustPackage {
     fileset = lib.fileset.unions [
       ../src
       ../tests
+      ../nix/direnv-compat.bash
       ../Cargo.toml
       ../Cargo.lock
     ];

--- a/src/cli/clap.rs
+++ b/src/cli/clap.rs
@@ -20,6 +20,11 @@ impl From<CliVerbosity> for crate::verbosity::Verbosity {
     }
 }
 
+#[derive(Clone, Copy, Debug, ValueEnum)]
+pub enum CliExportFormat {
+    Json,
+}
+
 #[derive(Subcommand)]
 pub enum CliAction {
     Enter {
@@ -39,6 +44,12 @@ pub enum CliAction {
     Edit,
     Hook {
         shell: String,
+    },
+    /// Internal compatibility endpoint used by the direnv shim.
+    #[command(hide = true)]
+    Export {
+        #[arg(value_enum)]
+        format: CliExportFormat,
     },
     Status,
 }

--- a/src/core.rs
+++ b/src/core.rs
@@ -1,9 +1,13 @@
+mod activation;
+
 use crate::{
     config,
+    env_delta::is_shell_managed,
+    shells::ShellOutput,
     types::{CadeAction, CadeLayer, EnvSet, HookType, InnerHook, Keyword, Loadable},
     verbosity::{self, Verbosity},
 };
-use anyhow::{Context, Result, anyhow, bail};
+use anyhow::{Context, Result, anyhow};
 use rusqlite::named_params;
 use serde::{Deserialize, Serialize};
 use std::{
@@ -60,7 +64,7 @@ fn log_disallowed_reminder() {
     verbosity::log(Verbosity::Normal, format_args!("{DISALLOWED_REMINDER}"));
 }
 
-fn mark_disallowed_root(root: &Path, shell: &dyn crate::shells::ShellOutput) {
+fn mark_disallowed_root(root: &Path, shell: &dyn ShellOutput) {
     let root = root.to_string_lossy();
     if std::env::var(DISALLOWED_ROOT_MARKER).as_deref() == Ok(root.as_ref()) {
         return;
@@ -70,7 +74,7 @@ fn mark_disallowed_root(root: &Path, shell: &dyn crate::shells::ShellOutput) {
     log_disallowed_reminder();
 }
 
-fn clear_disallowed_root_marker(shell: &dyn crate::shells::ShellOutput) {
+fn clear_disallowed_root_marker(shell: &dyn ShellOutput) {
     if std::env::var_os(DISALLOWED_ROOT_MARKER).is_some() {
         print!("{}", shell.unset_env(DISALLOWED_ROOT_MARKER));
     }
@@ -103,7 +107,7 @@ where
 pub struct RollupResult {
     pub env: HashMap<String, Vec<String>>,
     // vars that concatenate ambient values rather than clobbering them
-    pub absorb: std::collections::HashSet<String>,
+    pub absorb: HashSet<String>,
     pub unset: Vec<String>,
     pub hooks: Vec<InnerHook>,
     pub purified: bool,
@@ -144,20 +148,6 @@ struct WatchState {
     root: String,
     cade_paths: Vec<String>,
     files: Vec<WatchEntry>,
-}
-
-// Keys cade must never set from a layer: the shell owns them, or they're
-// cade's own bookkeeping.
-fn is_shell_managed(key: &str) -> bool {
-    matches!(key, "PWD" | "OLDPWD" | "SHLVL" | "_" | "LAST_EXIT_CODE") || key.starts_with("__CADE_")
-}
-
-fn is_pure_preserved_key(key: &str) -> bool {
-    is_shell_managed(key)
-        || matches!(
-            key,
-            "HOME" | "CADE_VERBOSITY" | "CADE_LONG_RUNNING_WARNING_MS"
-        )
 }
 
 fn has_config(dir: &Path) -> bool {
@@ -277,11 +267,12 @@ impl Cade {
     }
 
     /// Read the pre-activation environment snapshot for a session.
-    fn read_snapshot(&self, session: &str) -> HashMap<String, String> {
+    fn read_snapshot(&self, session: &str) -> Option<HashMap<String, String>> {
         if !is_valid_session(session) {
-            return HashMap::new();
+            return None;
         }
         std::fs::read_to_string(self.snapshot_path(session))
+            .ok()
             .map(|raw| {
                 raw.split('\x1F')
                     .filter_map(|e| {
@@ -290,7 +281,6 @@ impl Cade {
                     })
                     .collect()
             })
-            .unwrap_or_default()
     }
 
     fn write_snapshot(&self, session: &str, env: &HashMap<String, String>) -> Result<()> {
@@ -459,47 +449,10 @@ impl Cade {
         Ok(())
     }
 
-    pub fn do_activation(
-        &mut self,
-        shell: &dyn crate::shells::ShellOutput,
-        announce: Announce,
-    ) -> Result<()> {
-        let root = find_cade_root(&self.cwd)
-            .context("no .cade or .envrc found in this directory or any parent")?;
-
-        let cade_files = self.approved_chain(&root)?;
-        if cade_files.is_empty() {
-            bail!("{DISALLOWED_REMINDER}");
-        }
+    pub fn do_activation(&mut self, shell: &dyn ShellOutput, announce: Announce) -> Result<()> {
+        let plan = self.activation_plan()?;
         clear_disallowed_root_marker(shell);
-
-        let mut cade_layers = Vec::new();
-        let mut all_watch_files: Vec<PathBuf> = Vec::new();
-
-        for (layer_count, (path, keywords)) in cade_files.iter().enumerate() {
-            let watch_files = watched_files_for_keywords(path, keywords);
-            all_watch_files.extend(watch_files.clone());
-
-            let token = compute_layer_key(&watch_files);
-            let dir = path.to_string_lossy();
-            if let Some(cached) = self.get_cached_layer(&dir, &token)? {
-                verbosity::log(
-                    Verbosity::Trace,
-                    format_args!("cade: using cached layer {}.", path.display()),
-                );
-                cade_layers.push(cached);
-            } else {
-                verbosity::log(
-                    Verbosity::Trace,
-                    format_args!("cade: loading layer {}.", path.display()),
-                );
-                let layer = load_single_layer(layer_count, path, keywords)?;
-                self.store_cached_layer(&dir, &token, &layer)?;
-                cade_layers.push(layer);
-            }
-        }
-
-        let rollup = rollup_envs(cade_layers);
+        let rollup = &plan.rollup;
 
         for hook in &rollup.hooks {
             if hook.kind == HookType::LoadPre {
@@ -508,29 +461,13 @@ impl Cade {
             }
         }
 
-        // Baseline ambient environment (for concat and restore)
-        let baseline: HashMap<String, String> = match std::env::var("__CADE_SESSION") {
-            Ok(session) => self.read_snapshot(&session),
-            Err(_) => {
-                let live: HashMap<String, String> = std::env::vars()
-                    .filter(|(k, _)| !k.starts_with("__CADE_"))
-                    .collect();
-                let session = new_session_id();
-                self.gc_snapshots();
-                self.write_snapshot(&session, &live)?;
-                print!("{}", shell.set_env("__CADE_SESSION", &session));
-                live
-            }
-        };
+        let (activation_env, new_session) = self.activation_env_with_snapshot()?;
+        if let Some(session) = new_session {
+            print!("{}", shell.set_env("__CADE_SESSION", &session));
+        }
 
-        output_changes(
-            &rollup.env,
-            &rollup.absorb,
-            &rollup.unset,
-            rollup.purified,
-            &baseline,
-            shell,
-        );
+        let delta = rollup.env_delta(&activation_env);
+        print!("{}", delta.render_shell(shell));
 
         for hook in &rollup.hooks {
             if hook.kind == HookType::LoadPost {
@@ -539,7 +476,8 @@ impl Cade {
             }
         }
 
-        let layer_paths: Vec<String> = cade_files
+        let layer_paths: Vec<String> = plan
+            .cade_files
             .iter()
             .map(|(p, _)| p.to_string_lossy().to_string())
             .collect();
@@ -574,7 +512,7 @@ impl Cade {
         let hooks_json = serde_json::to_string(&rollup.hooks).unwrap_or_default();
         print!("{}", shell.set_env("__CADE_HOOKS", &hooks_json));
 
-        let watch_state = build_watch_state(&root, &all_watch_files);
+        let watch_state = build_watch_state(&plan.root, &plan.all_watch_files);
         let watches_json = serde_json::to_string(&watch_state).unwrap_or_default();
         print!("{}", shell.set_env("__CADE_WATCHES", &watches_json));
 
@@ -584,7 +522,7 @@ impl Cade {
             format_args!(
                 "cade: {} {}{}.",
                 announce.verb(),
-                root.display(),
+                plan.root.display(),
                 if extra > 0 {
                     format!(" (+{extra} parent layer(s))")
                 } else {
@@ -605,7 +543,7 @@ impl Cade {
     /// `announce: false` to suppress the unload message.
     pub fn do_restore(
         &mut self,
-        shell: &dyn crate::shells::ShellOutput,
+        shell: &dyn ShellOutput,
         finalise: bool,
         announce: bool,
     ) -> Result<()> {
@@ -618,7 +556,7 @@ impl Cade {
 
         let prev_env: HashMap<String, String> = session
             .as_deref()
-            .map(|s| self.read_snapshot(s))
+            .and_then(|s| self.read_snapshot(s))
             .unwrap_or_default();
 
         let set_keys = read_keylist("__CADE_SET");
@@ -732,7 +670,7 @@ impl Cade {
         Ok(())
     }
 
-    pub fn do_reload(&mut self, shell: &dyn crate::shells::ShellOutput) -> Result<()> {
+    pub fn do_reload(&mut self, shell: &dyn ShellOutput) -> Result<()> {
         let root = find_cade_root(&self.cwd);
         let is_active = std::env::var("__CADE_LAYERS").is_ok();
 
@@ -796,7 +734,7 @@ impl Cade {
     fn activate_if_permitted(
         &mut self,
         root: &Option<PathBuf>,
-        shell: &dyn crate::shells::ShellOutput,
+        shell: &dyn ShellOutput,
     ) -> Result<()> {
         if let Some(root) = root {
             if self.get_permission(root)? {
@@ -932,38 +870,6 @@ fn rollup_envs(cade_layers: Vec<CadeLayer>) -> RollupResult {
         unset,
         hooks,
         purified,
-    }
-}
-
-fn output_changes(
-    env: &HashMap<String, Vec<String>>,
-    absorb: &std::collections::HashSet<String>,
-    unset: &[String],
-    purified: bool,
-    baseline: &HashMap<String, String>,
-    shell: &dyn crate::shells::ShellOutput,
-) {
-    if purified {
-        for (k, _) in std::env::vars() {
-            if is_pure_preserved_key(&k) {
-                continue;
-            }
-            print!("{}", shell.unset_env(&k));
-        }
-    }
-    for k in unset {
-        print!("{}", shell.unset_env(k));
-    }
-    for (k, v) in env {
-        let mut value = v.join(":");
-        // concat vars keep ambient values, appended after .cade values
-        if !purified
-            && absorb.contains(k)
-            && let Some(amb) = baseline.get(k).filter(|a| !a.is_empty())
-        {
-            value = format!("{value}:{amb}");
-        }
-        print!("{}", shell.set_env(k, &value));
     }
 }
 
@@ -1305,25 +1211,6 @@ mod tests {
         // inherited parent-layer var survives pure (pure only discards ambient)
         assert_eq!(r.env["FROM_PARENT"], vec!["kept"]);
         assert_eq!(r.env["FROM_CHILD"], vec!["c"]);
-    }
-
-    #[test]
-    fn shell_managed_classification() {
-        for k in [
-            "PWD",
-            "OLDPWD",
-            "SHLVL",
-            "_",
-            "LAST_EXIT_CODE",
-            "__CADE_PREV",
-            "__CADE_SET",
-        ] {
-            assert!(is_shell_managed(k), "{k} should be shell-managed");
-        }
-        for k in ["PATH", "HOME", "MY_VAR"] {
-            assert!(!is_shell_managed(k), "{k} should not be shell-managed");
-        }
-        assert!(is_pure_preserved_key("HOME"));
     }
 
     #[test]

--- a/src/core/activation.rs
+++ b/src/core/activation.rs
@@ -1,0 +1,156 @@
+use super::{
+    Cade, DISALLOWED_REMINDER, Keyword, RollupResult, compute_layer_key, find_cade_root,
+    load_single_layer, new_session_id, rollup_envs, watched_files_for_keywords,
+};
+use crate::{
+    direnv_export,
+    env_delta::{EnvDelta, EnvDeltaInput, live_ambient_env},
+    verbosity::{self, Verbosity},
+};
+use anyhow::{Context, Result, anyhow};
+use std::{collections::HashMap, path::PathBuf};
+
+pub(super) struct ActivationPlan {
+    pub(super) root: PathBuf,
+    pub(super) cade_files: Vec<(PathBuf, Vec<Keyword>)>,
+    pub(super) all_watch_files: Vec<PathBuf>,
+    pub(super) rollup: RollupResult,
+}
+
+pub(super) struct ActivationEnv {
+    live: HashMap<String, String>,
+    baseline: HashMap<String, String>,
+}
+
+impl RollupResult {
+    pub(super) fn env_delta(&self, activation_env: &ActivationEnv) -> EnvDelta {
+        // Shell activation and JSON export share this calculation so new cade
+        // semantics cannot accidentally work in one path and diverge in the
+        // other.
+        EnvDelta::from_rollup(EnvDeltaInput {
+            env: &self.env,
+            absorb: &self.absorb,
+            unset: &self.unset,
+            purified: self.purified,
+            live_env: &activation_env.live,
+            baseline: &activation_env.baseline,
+        })
+    }
+}
+
+impl Cade {
+    pub(super) fn activation_plan(&mut self) -> Result<ActivationPlan> {
+        let root = find_cade_root(&self.cwd)
+            .context("no .cade or .envrc found in this directory or any parent")?;
+        self.activation_plan_for_root(root)
+    }
+
+    fn activation_plan_for_root(&mut self, root: PathBuf) -> Result<ActivationPlan> {
+        self.maybe_activation_plan_for_root(root)?
+            .ok_or_else(|| anyhow!("{DISALLOWED_REMINDER}"))
+    }
+
+    fn maybe_activation_plan_for_root(&mut self, root: PathBuf) -> Result<Option<ActivationPlan>> {
+        let cade_files = self.approved_chain(&root)?;
+        if cade_files.is_empty() {
+            return Ok(None);
+        }
+
+        let mut cade_layers = Vec::new();
+        let mut all_watch_files: Vec<PathBuf> = Vec::new();
+
+        for (layer_count, (path, keywords)) in cade_files.iter().enumerate() {
+            let watch_files = watched_files_for_keywords(path, keywords);
+            all_watch_files.extend(watch_files.clone());
+
+            let token = compute_layer_key(&watch_files);
+            let dir = path.to_string_lossy();
+            if let Some(cached) = self.get_cached_layer(&dir, &token)? {
+                verbosity::log(
+                    Verbosity::Trace,
+                    format_args!("cade: using cached layer {}.", path.display()),
+                );
+                cade_layers.push(cached);
+            } else {
+                verbosity::log(
+                    Verbosity::Trace,
+                    format_args!("cade: loading layer {}.", path.display()),
+                );
+                let layer = load_single_layer(layer_count, path, keywords)?;
+                self.store_cached_layer(&dir, &token, &layer)?;
+                cade_layers.push(layer);
+            }
+        }
+
+        let rollup = rollup_envs(cade_layers);
+
+        Ok(Some(ActivationPlan {
+            root,
+            cade_files,
+            all_watch_files,
+            rollup,
+        }))
+    }
+
+    pub(super) fn activation_env_with_snapshot(&self) -> Result<(ActivationEnv, Option<String>)> {
+        let live = live_ambient_env();
+        match std::env::var("__CADE_SESSION") {
+            Ok(session) => {
+                // Existing cade shells reuse their original pre-activation
+                // snapshot. Using the already-mutated live env here would make
+                // concat variables such as PATH grow on reload.
+                let baseline = self.read_snapshot(&session).unwrap_or_else(|| live.clone());
+                Ok((ActivationEnv { live, baseline }, None))
+            }
+            Err(_) => {
+                // First activation creates the baseline snapshot before any
+                // cade changes are emitted to the shell.
+                let session = new_session_id();
+                self.gc_snapshots();
+                self.write_snapshot(&session, &live)?;
+                Ok((
+                    ActivationEnv {
+                        baseline: live.clone(),
+                        live,
+                    },
+                    Some(session),
+                ))
+            }
+        }
+    }
+
+    fn export_session(&self) -> direnv_export::ExportSession {
+        let snapshot = std::env::var("__CADE_SESSION")
+            .ok()
+            .and_then(|session| self.read_snapshot(&session));
+        direnv_export::capture_session(snapshot)
+    }
+
+    pub fn export_env_delta(&mut self) -> Result<EnvDelta> {
+        let export = self.export_session();
+        let Some(root) = find_cade_root(&self.cwd) else {
+            // This mirrors direnv's unload behavior for direct callers: leaving
+            // a project must undo the last exported diff if the caller preserved
+            // DIRENV_DIFF.
+            return Ok(direnv_export::inactive_delta(export.previous));
+        };
+        let Some(plan) = self.maybe_activation_plan_for_root(root)? else {
+            if export.previous.is_some() {
+                // A project can become disallowed while an editor still holds
+                // its previous env. Restore that env instead of leaving stale
+                // project variables active.
+                return Ok(direnv_export::inactive_delta(export.previous));
+            }
+            anyhow::bail!(
+                "cade project is not allowed; run `cade allow` in {}",
+                self.cwd.display()
+            );
+        };
+        let activation_env = ActivationEnv {
+            live: export.live,
+            baseline: export.baseline,
+        };
+        let delta = plan.rollup.env_delta(&activation_env);
+        direnv_export::active_delta(delta, activation_env.baseline, export.previous)
+    }
+}

--- a/src/direnv_export.rs
+++ b/src/direnv_export.rs
@@ -1,0 +1,158 @@
+//! Direnv-compatible JSON export for editors and tools such as Zed.
+//!
+//! `DIRENV_DIFF` only tracks the previous values for variables cade changed.
+//! That keeps repeated `direnv export json` calls idempotent when the caller
+//! preserves the returned project environment between calls.
+//!
+//! This is deliberately not cade's interactive shell path. Shell hooks get
+//! `__CADE_SESSION` snapshots and hook bookkeeping; this adapter returns only
+//! the environment diff expected by direnv-compatible tools.
+
+use crate::env_delta::{EnvDelta, is_shell_managed, live_ambient_env};
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeSet, HashMap};
+
+const DIRENV_DIFF: &str = "DIRENV_DIFF";
+
+#[derive(Debug, Serialize, Deserialize)]
+pub(crate) struct ExportState {
+    version: u8,
+    preimage: HashMap<String, Option<String>>,
+}
+
+pub(crate) struct ExportSession {
+    pub live: HashMap<String, String>,
+    pub baseline: HashMap<String, String>,
+    pub previous: Option<ExportState>,
+}
+
+pub(crate) fn capture_session(snapshot: Option<HashMap<String, String>>) -> ExportSession {
+    let live = live_ambient_env();
+    let previous = export_state(&live);
+    // Prefer DIRENV_DIFF when present because it is the only state a direct
+    // direnv caller, such as Zed, carries between invocations. Native cade
+    // shells still use their __CADE_SESSION snapshot as the baseline.
+    let baseline = previous
+        .as_ref()
+        .map(|state| state.baseline_from_live(&live))
+        .or(snapshot)
+        .unwrap_or_else(|| live_baseline(&live));
+
+    ExportSession {
+        live,
+        baseline,
+        previous,
+    }
+}
+
+pub(crate) fn inactive_delta(previous: Option<ExportState>) -> EnvDelta {
+    let Some(previous) = previous else {
+        return EnvDelta::empty();
+    };
+
+    // Direnv asks for a diff on every directory change. When the new directory
+    // has no active cade project, returning `{}` would leave the old project's
+    // PATH and variables stuck in the editor environment.
+    let mut delta = EnvDelta::empty();
+    restore_applied(&mut delta, &previous);
+    delta.record(DIRENV_DIFF, None);
+    delta
+}
+
+pub(crate) fn active_delta(
+    mut delta: EnvDelta,
+    baseline: HashMap<String, String>,
+    previous: Option<ExportState>,
+) -> Result<EnvDelta> {
+    let applied = tracked_delta_keys(&delta);
+
+    if let Some(previous) = previous.as_ref() {
+        // If a variable was changed by the previous activation but is not
+        // produced by the new one, restore its preimage. This is what prevents
+        // stale variables from surviving reloads or project switches.
+        for (key, preimage) in previous.tracked_preimages() {
+            if delta.contains(key) {
+                continue;
+            }
+            delta.record(key, preimage.cloned());
+        }
+    }
+
+    let preimage = applied
+        .iter()
+        .map(|key| {
+            // Preserve the original preimage across repeated exports. Reading
+            // from `live` here would make PATH grow as callers feed the prior
+            // exported environment back into the next `direnv export json`.
+            let value = previous
+                .as_ref()
+                .and_then(|state| state.preimage.get(key).cloned())
+                .unwrap_or_else(|| baseline.get(key).cloned());
+            (key.clone(), value)
+        })
+        .collect();
+    let state = ExportState {
+        version: 2,
+        preimage,
+    };
+    delta.record(DIRENV_DIFF, Some(serde_json::to_string(&state)?));
+    Ok(delta)
+}
+
+fn export_state(live: &HashMap<String, String>) -> Option<ExportState> {
+    let state = live.get(DIRENV_DIFF)?;
+    let state: ExportState = serde_json::from_str(state).ok()?;
+    (state.version == 2).then_some(state)
+}
+
+fn live_baseline(live: &HashMap<String, String>) -> HashMap<String, String> {
+    let mut baseline = live.clone();
+    baseline.remove(DIRENV_DIFF);
+    baseline
+}
+
+fn restore_applied(delta: &mut EnvDelta, previous: &ExportState) {
+    for (key, preimage) in previous.tracked_preimages() {
+        delta.record(key, preimage.cloned());
+    }
+}
+
+fn tracked_delta_keys(delta: &EnvDelta) -> BTreeSet<String> {
+    delta
+        .keys()
+        .filter(|key| is_tracked_key(key))
+        .map(ToOwned::to_owned)
+        .collect()
+}
+
+fn is_tracked_key(key: &str) -> bool {
+    key != DIRENV_DIFF && !is_shell_managed(key)
+}
+
+impl ExportState {
+    fn tracked_preimages(&self) -> impl Iterator<Item = (&str, Option<&String>)> {
+        self.preimage
+            .iter()
+            .filter(|(key, _)| is_tracked_key(key))
+            .map(|(key, value)| (key.as_str(), value.as_ref()))
+    }
+
+    fn baseline_from_live(&self, live: &HashMap<String, String>) -> HashMap<String, String> {
+        let mut baseline = live_baseline(live);
+        // Reconstruct the user's original environment by undoing only the
+        // variables cade previously touched. Untouched variables are left as
+        // they appear in the caller's current project environment.
+        for (key, preimage) in &self.preimage {
+            match preimage {
+                Some(value) => {
+                    baseline.insert(key.clone(), value.clone());
+                }
+                None => {
+                    baseline.remove(key);
+                }
+            }
+        }
+        baseline
+    }
+}

--- a/src/env_delta.rs
+++ b/src/env_delta.rs
@@ -1,0 +1,172 @@
+//! Shared environment-diff model.
+//!
+//! Shell activation and `export json` must compute the same variable changes.
+//! Keeping the diff here avoids maintaining a second activation implementation
+//! for editor/direnv compatibility.
+
+use crate::shells::{self, ShellOutput};
+use std::collections::{BTreeMap, HashMap, HashSet};
+
+type EnvDiff = BTreeMap<String, Option<String>>;
+
+pub(crate) struct EnvDelta {
+    changes: EnvDiff,
+}
+
+pub(crate) struct EnvDeltaInput<'a> {
+    pub(crate) env: &'a HashMap<String, Vec<String>>,
+    pub(crate) absorb: &'a HashSet<String>,
+    pub(crate) unset: &'a [String],
+    pub(crate) purified: bool,
+    /// Current process environment after any previous cade/direnv activation.
+    pub(crate) live_env: &'a HashMap<String, String>,
+    /// Pre-activation environment for concat/restore semantics.
+    pub(crate) baseline: &'a HashMap<String, String>,
+}
+
+impl EnvDelta {
+    pub(crate) fn empty() -> Self {
+        Self {
+            changes: EnvDiff::new(),
+        }
+    }
+
+    pub(crate) fn from_rollup(input: EnvDeltaInput<'_>) -> Self {
+        let EnvDeltaInput {
+            env,
+            absorb,
+            unset,
+            purified,
+            live_env,
+            baseline,
+        } = input;
+        let mut changes = EnvDiff::new();
+
+        if purified {
+            // Pure activation must clear variables from both the current
+            // environment and the original baseline; otherwise a later restore
+            // path can leave behind variables that were absent from `live_env`.
+            for k in live_env.keys().chain(baseline.keys()) {
+                if !is_pure_preserved_key(k) {
+                    record_change(&mut changes, k, None);
+                }
+            }
+        }
+
+        for k in unset {
+            record_change(&mut changes, k, None);
+        }
+
+        for (k, v) in env {
+            let mut value = v.join(":");
+            // concat vars keep ambient values, appended after .cade values
+            if !purified
+                && absorb.contains(k)
+                && let Some(amb) = baseline.get(k).filter(|a| !a.is_empty())
+            {
+                value = format!("{value}:{amb}");
+            }
+            record_change(&mut changes, k, Some(value));
+        }
+
+        Self { changes }
+    }
+
+    pub(crate) fn render_shell(&self, shell: &dyn ShellOutput) -> String {
+        let mut output = String::new();
+        for (k, v) in &self.changes {
+            match v {
+                Some(value) => output.push_str(&shell.set_env(k, value)),
+                None => output.push_str(&shell.unset_env(k)),
+            }
+        }
+        output
+    }
+
+    pub(crate) fn contains(&self, key: &str) -> bool {
+        self.changes.contains_key(key)
+    }
+
+    pub(crate) fn keys(&self) -> impl Iterator<Item = &str> {
+        self.changes.keys().map(String::as_str)
+    }
+
+    pub(crate) fn record(&mut self, key: &str, value: Option<String>) {
+        record_change(&mut self.changes, key, value);
+    }
+
+    pub(crate) fn to_json(&self) -> String {
+        format!(
+            "{}\n",
+            serde_json::to_string(&self.changes).expect("env diff serializes")
+        )
+    }
+}
+
+pub(crate) fn live_ambient_env() -> HashMap<String, String> {
+    // Cade internals describe the active session, not the user's ambient
+    // environment. Treating them as ambient would leak activation bookkeeping
+    // through `export json` and into concat baselines.
+    std::env::vars()
+        .filter(|(k, _)| !k.starts_with("__CADE_"))
+        .collect()
+}
+
+// Keys cade must never set from a layer: the shell owns them, or they're
+// cade's own bookkeeping.
+pub(crate) fn is_shell_managed(key: &str) -> bool {
+    matches!(key, "PWD" | "OLDPWD" | "SHLVL" | "_" | "LAST_EXIT_CODE") || key.starts_with("__CADE_")
+}
+
+fn is_pure_preserved_key(key: &str) -> bool {
+    is_shell_managed(key)
+        || matches!(
+            key,
+            "HOME" | "CADE_VERBOSITY" | "CADE_LONG_RUNNING_WARNING_MS"
+        )
+}
+
+fn record_change(changes: &mut EnvDiff, key: &str, value: Option<String>) {
+    if shells::is_valid_key(key) {
+        changes.insert(key.to_string(), value);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn shell_managed_classification() {
+        for k in [
+            "PWD",
+            "OLDPWD",
+            "SHLVL",
+            "_",
+            "LAST_EXIT_CODE",
+            "__CADE_PREV",
+            "__CADE_SET",
+        ] {
+            assert!(is_shell_managed(k), "{k} should be shell-managed");
+        }
+        for k in ["PATH", "HOME", "MY_VAR"] {
+            assert!(!is_shell_managed(k), "{k} should not be shell-managed");
+        }
+        assert!(is_pure_preserved_key("HOME"));
+    }
+
+    #[test]
+    fn json_escapes_separators() {
+        let delta = EnvDelta {
+            changes: EnvDiff::from([
+                ("A".to_string(), Some("x\x1fy".to_string())),
+                ("B".to_string(), None),
+            ]),
+        };
+        let out = delta.to_json();
+        // strict parse proves the U+001F separator was escaped, not emitted raw
+        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(v["A"], "x\x1fy");
+        assert!(v["B"].is_null());
+    }
+}

--- a/src/envs.rs
+++ b/src/envs.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use crate::types::EnvSet;
-use anyhow::{Context, Result, anyhow, bail};
+use anyhow::{Result, bail};
 
 /// Normalize a raw .env value
 fn clean_env_value(raw: &str) -> String {
@@ -52,113 +52,6 @@ impl EnvSet {
                 .or_insert(values);
         }
         Ok(EnvSet { vars, hard })
-    }
-    pub fn from_json(raw: &[u8]) -> Result<EnvSet> {
-        let json: serde_json::Value = serde_json::from_slice(raw).context("parsing json")?;
-        if json.is_object()
-            && let Some(all_vars) = json.get("variables")
-        {
-            let vars = all_vars
-                .as_object()
-                .map(|inner| {
-                    inner
-                        .iter()
-                        .filter(|(var, _)| {
-                            !(var.starts_with("NIX_")
-                                || var.starts_with("output")
-                                || var.starts_with("deps")
-                                || var.starts_with("enable")
-                                || var.ends_with("Inputs")
-                                || var.ends_with("Flags")
-                                || var.ends_with("TYPE")
-                                || var.to_lowercase().contains("phase")
-                                || matches!(
-                                    var.as_str(),
-                                    "SHELL"
-                                        | "pkg"
-                                        | "prefix"
-                                        | "guess"
-                                        | "_substituteStream_has_warned_replace_deprecation"
-                                        | "LINENO"
-                                        | "OPTERROR"
-                                        | "OLDPWD"
-                                        | "BASH"
-                                        | "IFS"
-                                        | "PS4"
-                                        | "initialPath"
-                                        | "out"
-                                        | "shell"
-                                        | "STRINGS"
-                                        | "stdenv"
-                                        | "builder"
-                                        | "PWD"
-                                        | "SOURCE_DATE_EPOCH"
-                                        | "CXX"
-                                        | "TEMPDIR"
-                                        | "system"
-                                        | "HOST_PATH"
-                                        | "doInstallCheck"
-                                        | "buildCommandPath"
-                                        | "LS_COLORS"
-                                        | "cmakeFlakes"
-                                        | "TMPDIR"
-                                        | "LD"
-                                        | "READELF"
-                                        | "doCheck"
-                                        | "SIZE"
-                                        | "propagatedNativeBuildInputs"
-                                        | "strictDeps"
-                                        | "AR"
-                                        | "AS"
-                                        | "TEMP"
-                                        | "SHLVL"
-                                        | "NM"
-                                        | "patches"
-                                        | "passAsFile"
-                                        | "buildInputs"
-                                        | "SSL_CERT_FILE"
-                                        | "OBJCOPY"
-                                        | "STRIP"
-                                        | "TMP"
-                                        | "OBJDUMP"
-                                        | "propagatedBuildInputs"
-                                        | "CC"
-                                        | "__ETC_PROFILE_SOURCED"
-                                        | "CONFIG_SHELL"
-                                        | "__structuredAttrs"
-                                        | "RANLIB"
-                                        | "nativeBuildInputs"
-                                        | "name"
-                                        | "TEST"
-                                        | "TZ"
-                                        | "HOME"
-                                        | "GZIP_NO_TIMESTAMPS"
-                                        | "cmakeFlags"
-                                        | "TERM"
-                                        | "buildCommand"
-                                        | "preferLocalBuild"
-                                        | "dontAddDisableDepTrack"
-                                ))
-                        })
-                        .filter_map(|var| {
-                            Some((var.0.to_string(), var.1.get("value")?.as_str()?.to_owned()))
-                        })
-                        .map(|(name, value)| {
-                            (
-                                name,
-                                value
-                                    .split(':')
-                                    .map(|s| s.to_string())
-                                    .collect::<Vec<String>>(),
-                            )
-                        })
-                        .collect()
-                })
-                .context("collecting env vars")?;
-            Ok(EnvSet::from_vars(vars))
-        } else {
-            Err(anyhow!("failed to parse values from JSON output"))
-        }
     }
 }
 

--- a/src/loaders.rs
+++ b/src/loaders.rs
@@ -13,6 +13,8 @@ use std::{
     time::{Duration, Instant},
 };
 
+pub(crate) use crate::nix_dev_env::{load_flake, load_shell};
+
 const DEFAULT_LONG_RUNNING_WARNING_AFTER: Duration = Duration::from_secs(5);
 const LONG_RUNNING_POLL_INTERVAL: Duration = Duration::from_millis(100);
 const RECENT_OUTPUT_LINES: usize = 3;
@@ -256,7 +258,7 @@ fn handle_stream_event(
 }
 
 /// Run a command, returning stdout on success or an error carrying its stderr
-fn run_checked(mut cmd: Command, what: &str) -> Result<Vec<u8>> {
+pub(crate) fn run_checked(mut cmd: Command, what: &str) -> Result<Vec<u8>> {
     verbosity::log(Verbosity::Trace, format_args!("cade: running {what}."));
 
     let (tx, rx) = std::sync::mpsc::channel();
@@ -347,34 +349,6 @@ fn run_checked(mut cmd: Command, what: &str) -> Result<Vec<u8>> {
         );
     }
     Ok(out.stdout)
-}
-
-pub fn load_flake(path: &Path, output: Option<String>) -> Result<EnvSet> {
-    let mut proc = Command::new("nix");
-    proc.args(["print-dev-env", "--json"]);
-    // A named output is a flake installable
-    if let Some(flake_output) = output.filter(|o| !o.is_empty()) {
-        proc.arg(format!(".#{flake_output}"));
-    }
-    proc.current_dir(path);
-    let stdout = run_checked(proc, &format!("nix print-dev-env at {}", path.display()))?;
-    EnvSet::from_json(&stdout)
-}
-
-pub fn load_shell(path: &Path, filename: String) -> Result<EnvSet> {
-    let file = if filename.is_empty() {
-        "./shell.nix".to_string()
-    } else {
-        filename
-    };
-    let mut proc = Command::new("nix");
-    proc.args(["print-dev-env", "--json", "-f", &file]);
-    proc.current_dir(path);
-    let stdout = run_checked(
-        proc,
-        &format!("nix print-dev-env -f {file} at {}", path.display()),
-    )?;
-    EnvSet::from_json(&stdout)
 }
 
 pub fn load_env(path: &Path, filename: String) -> Result<EnvSet> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,12 @@
 mod cli;
 mod config;
 mod core;
+mod direnv_export;
+mod env_delta;
 mod envrc;
 mod envs;
 mod loaders;
+mod nix_dev_env;
 mod shells;
 mod types;
 mod verbosity;
@@ -68,6 +71,12 @@ fn try_main() -> Result<()> {
             cade.do_reload(output.as_ref())
                 .context("reload cade environment")?;
         }
+        Export { format } => match format {
+            cli::clap::CliExportFormat::Json => {
+                let delta = cade.export_env_delta().context("export cade environment")?;
+                print!("{}", delta.to_json());
+            }
+        },
         Allow => cade.allow_here(true)?,
         Disallow => cade.allow_here(false)?,
         Edit => {

--- a/src/nix_dev_env.rs
+++ b/src/nix_dev_env.rs
@@ -1,0 +1,311 @@
+//! Capture the final Nix dev-shell process environment.
+//!
+//! `nix print-dev-env --json` is convenient, but it describes the build
+//! environment before bash evaluates shell setup such as devshell/shellHook PATH
+//! changes. The non-JSON `print-dev-env` shell script can produce the right
+//! result, but evaluating it correctly would make cade run bash itself. Instead,
+//! `nix develop --command` lets Nix own that setup, and cade only dumps the
+//! resulting process environment.
+
+use crate::{loaders::run_checked, types::EnvSet};
+use anyhow::{Context, Result, bail};
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+const ENV_MARKER: &[u8] = b"\0__CADE_ENV_BEGIN__\0";
+const ENV_CAPTURE_SCRIPT: &str = "printf '\\0__CADE_ENV_BEGIN__\\0'\nexec \"$1\" -0";
+
+// Nix exposes many derivation/build variables in a dev shell. Cade only wants
+// user-facing environment changes, so keep the historical filter from the old
+// `print-dev-env --json` path and apply it to the captured env dump.
+const IGNORED_ENV_PREFIXES: &[&str] = &["NIX_", "output", "deps", "enable"];
+const IGNORED_ENV_SUFFIXES: &[&str] = &["Inputs", "Flags", "TYPE"];
+const IGNORED_ENV_KEYS: &[&str] = &[
+    "SHELL",
+    "pkg",
+    "prefix",
+    "guess",
+    "_substituteStream_has_warned_replace_deprecation",
+    "LINENO",
+    "OPTERROR",
+    "OLDPWD",
+    "BASH",
+    "IFS",
+    "PS4",
+    "initialPath",
+    "out",
+    "shell",
+    "STRINGS",
+    "stdenv",
+    "builder",
+    "PWD",
+    "SOURCE_DATE_EPOCH",
+    "CXX",
+    "TEMPDIR",
+    "system",
+    "HOST_PATH",
+    "doInstallCheck",
+    "buildCommandPath",
+    "LS_COLORS",
+    "cmakeFlakes",
+    "TMPDIR",
+    "LD",
+    "READELF",
+    "doCheck",
+    "SIZE",
+    "propagatedNativeBuildInputs",
+    "strictDeps",
+    "AR",
+    "AS",
+    "TEMP",
+    "SHLVL",
+    "NM",
+    "patches",
+    "passAsFile",
+    "buildInputs",
+    "SSL_CERT_FILE",
+    "OBJCOPY",
+    "STRIP",
+    "TMP",
+    "OBJDUMP",
+    "propagatedBuildInputs",
+    "CC",
+    "__ETC_PROFILE_SOURCED",
+    "CONFIG_SHELL",
+    "__structuredAttrs",
+    "RANLIB",
+    "nativeBuildInputs",
+    "name",
+    "TEST",
+    "TZ",
+    "HOME",
+    "GZIP_NO_TIMESTAMPS",
+    "cmakeFlags",
+    "TERM",
+    "buildCommand",
+    "preferLocalBuild",
+    "dontAddDisableDepTrack",
+];
+
+pub(crate) fn load_flake(path: &Path, output: Option<String>) -> Result<EnvSet> {
+    let mut proc = Command::new("nix");
+    proc.arg("develop");
+    // A named output is a flake installable.
+    if let Some(flake_output) = output.filter(|o| !o.is_empty()) {
+        proc.arg(format!(".#{flake_output}"));
+    }
+    add_env_command(&mut proc);
+
+    load_nix_dev_env(proc, path, &format!("at {}", path.display()))
+}
+
+pub(crate) fn load_shell(path: &Path, filename: String) -> Result<EnvSet> {
+    let file = if filename.is_empty() {
+        "./shell.nix".to_string()
+    } else {
+        filename
+    };
+    let mut proc = Command::new("nix");
+    proc.args(["develop", "-f", &file]);
+    add_env_command(&mut proc);
+    load_nix_dev_env(proc, path, &format!("-f {file} at {}", path.display()))
+}
+
+fn load_nix_dev_env(mut proc: Command, path: &Path, what: &str) -> Result<EnvSet> {
+    let previous_env: HashMap<_, _> = std::env::vars().collect();
+    proc.current_dir(path);
+    let stdout = run_checked(proc, &format!("nix develop {what}"))?;
+    let stdout = captured_env_stdout(&stdout, what)?;
+    env_set_from_captured_env(stdout, &previous_env)
+}
+
+fn add_env_command(proc: &mut Command) {
+    // Use absolute sh/env paths when possible. Once inside `nix develop`,
+    // PATH may intentionally be incomplete or rewritten by the shell setup.
+    proc.args(["--command"])
+        .arg(find_on_path("sh"))
+        .args(["-c", ENV_CAPTURE_SCRIPT, "cade-env"])
+        .arg(find_on_path("env"));
+}
+
+fn find_on_path(name: &str) -> PathBuf {
+    std::env::var_os("PATH")
+        .and_then(|path| {
+            std::env::split_paths(&path)
+                .map(|dir| dir.join(name))
+                .find(|candidate| candidate.is_file())
+        })
+        .unwrap_or_else(|| PathBuf::from(name))
+}
+
+fn captured_env_stdout<'a>(stdout: &'a [u8], what: &str) -> Result<&'a [u8]> {
+    // Hooks may print banners or warnings before our command runs. The NUL
+    // marker makes the env dump unambiguous without imposing silence on hooks.
+    let Some(start) = stdout
+        .windows(ENV_MARKER.len())
+        .position(|window| window == ENV_MARKER)
+    else {
+        bail!("nix develop {what} did not emit a captured environment marker");
+    };
+
+    Ok(&stdout[start + ENV_MARKER.len()..])
+}
+
+fn env_set_from_captured_env(raw: &[u8], previous: &HashMap<String, String>) -> Result<EnvSet> {
+    let path_suffix = previous.get("PATH").map(String::as_str);
+    let mut vars: HashMap<String, Vec<String>> = HashMap::new();
+
+    // env -0 avoids newline/shell quoting ambiguities. Environment variables
+    // cannot contain NUL bytes, so this is the lossless delimiter available to
+    // ordinary Unix process environments.
+    for entry in raw.split(|&b| b == b'\0').filter(|entry| !entry.is_empty()) {
+        let text = std::str::from_utf8(entry).context("parsing exported environment")?;
+        let Some((key, raw_value)) = text.split_once('=') else {
+            continue;
+        };
+        if !keep_loaded_env_var(key) {
+            continue;
+        }
+        if previous.get(key).is_some_and(|value| value == raw_value) {
+            continue;
+        }
+
+        let value = if key == "PATH" {
+            clean_captured_path(raw_value, path_suffix)
+        } else {
+            raw_value.to_string()
+        };
+        if key == "PATH" && value.is_empty() {
+            continue;
+        }
+
+        vars.insert(
+            key.to_string(),
+            value.split(':').map(|s| s.to_string()).collect(),
+        );
+    }
+
+    Ok(EnvSet::from_vars(vars))
+}
+
+fn keep_loaded_env_var(var: &str) -> bool {
+    !(IGNORED_ENV_PREFIXES
+        .iter()
+        .any(|prefix| var.starts_with(prefix))
+        || IGNORED_ENV_SUFFIXES
+            .iter()
+            .any(|suffix| var.ends_with(suffix))
+        || var.to_lowercase().contains("phase")
+        || IGNORED_ENV_KEYS.contains(&var))
+}
+
+fn clean_captured_path(value: &str, path_suffix: Option<&str>) -> String {
+    let mut parts: Vec<&str> = value
+        .split(':')
+        .filter(|part| !part.is_empty() && *part != "/path-not-set")
+        .collect();
+
+    if let Some(suffix) = path_suffix {
+        // `nix develop --command` appends the runner's PATH after the dev-shell
+        // entries. Cade later concatenates with the ambient PATH itself, so
+        // keeping this suffix would duplicate the caller's PATH on activation.
+        let suffix_parts: Vec<&str> = suffix
+            .split(':')
+            .filter(|part| !part.is_empty() && *part != "/path-not-set")
+            .collect();
+        if !suffix_parts.is_empty() && parts.ends_with(&suffix_parts) {
+            parts.truncate(parts.len() - suffix_parts.len());
+        }
+    }
+
+    parts.join(":")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn add_env_command_uses_resolved_env_binary() {
+        let mut proc = Command::new("nix");
+        add_env_command(&mut proc);
+        let args: Vec<_> = proc.get_args().map(|arg| arg.to_owned()).collect();
+
+        assert_eq!(args[0], "--command");
+        assert!(Path::new(&args[1]).is_absolute() || args[1] == "sh");
+        assert_eq!(args[2], "-c");
+        assert_eq!(args[3], ENV_CAPTURE_SCRIPT);
+        assert_eq!(args[4], "cade-env");
+        assert!(Path::new(&args[5]).is_absolute() || args[5] == "env");
+    }
+
+    #[test]
+    fn captured_env_stdout_skips_hook_output() {
+        let stdout = b"hello from hook\n\0__CADE_ENV_BEGIN__\0PATH=/dev/bin\0";
+        assert_eq!(
+            captured_env_stdout(stdout, "test").unwrap(),
+            b"PATH=/dev/bin\0"
+        );
+    }
+
+    #[test]
+    fn captured_env_strips_runner_path_suffix_and_nix_sentinel() {
+        let previous = HashMap::from([("PATH".to_string(), "/usr/bin:/bin".to_string())]);
+        let env = env_set_from_captured_env(
+            b"PATH=/dev/bin:/path-not-set:/usr/bin:/bin\0FOO=bar\0",
+            &previous,
+        )
+        .unwrap();
+
+        assert_eq!(env.vars["PATH"], vec!["/dev/bin"]);
+        assert_eq!(env.vars["FOO"], vec!["bar"]);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn nix_dev_env_capture_keeps_shell_hook_path_changes() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let root = std::env::temp_dir().join(format!(
+            "cade-loader-{}-{}",
+            std::process::id(),
+            std::thread::current().name().unwrap_or("test")
+        ));
+        std::fs::create_dir_all(&root).unwrap();
+        let fake_nix = root.join("nix");
+        let shell = find_on_path("sh");
+        let script = format!(
+            r#"#!{}
+set -eu
+while [ "$#" -gt 0 ] && [ "$1" != "--command" ]; do
+  shift
+done
+if [ "$#" -eq 0 ]; then
+  exit 64
+fi
+shift
+PATH="/hook/bin:/path-not-set:${{PATH:-}}"
+export PATH
+FROM_HOOK=ok
+export FROM_HOOK
+exec "$@"
+"#,
+            shell.display()
+        );
+        std::fs::write(&fake_nix, script).unwrap();
+        let mut permissions = std::fs::metadata(&fake_nix).unwrap().permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&fake_nix, permissions).unwrap();
+
+        let mut proc = Command::new(&fake_nix);
+        add_env_command(&mut proc);
+        let env = load_nix_dev_env(proc, &root, "fake nix").unwrap();
+        std::fs::remove_dir_all(&root).ok();
+
+        assert_eq!(env.vars["FROM_HOOK"], vec!["ok"]);
+        assert_eq!(env.vars["PATH"], vec!["/hook/bin"]);
+    }
+}

--- a/src/shells.rs
+++ b/src/shells.rs
@@ -54,6 +54,18 @@ fn fish_command(cade_exe: &str, cade_args: &[String]) -> String {
         .join(" ")
 }
 
+fn nushell_env_value(key: &str, value: &str) -> serde_json::Value {
+    if key == "PATH" {
+        return serde_json::Value::Array(
+            std::env::split_paths(value)
+                .map(|path| serde_json::Value::from(path.to_string_lossy().into_owned()))
+                .collect(),
+        );
+    }
+
+    serde_json::Value::from(value)
+}
+
 #[derive(Debug, Clone, Copy)]
 pub enum ShellName {
     Fish,
@@ -127,6 +139,7 @@ impl ShellOutput for Fish {
     fn emit_hook(&self, command: &str) -> String {
         format!("{command};")
     }
+
     fn hook_init(&self, cade_exe: &str, cade_args: &[String]) -> String {
         r#"function __cade_hook --on-event fish_prompt
     set -l __cade_status $status
@@ -158,6 +171,7 @@ impl ShellOutput for Bash {
     fn emit_hook(&self, command: &str) -> String {
         format!("{command};")
     }
+
     fn hook_init(&self, cade_exe: &str, cade_args: &[String]) -> String {
         r#"_cade_hook() {
     local previous_exit_status=$?
@@ -194,6 +208,7 @@ impl ShellOutput for Zsh {
     fn emit_hook(&self, command: &str) -> String {
         format!("{command};")
     }
+
     fn hook_init(&self, cade_exe: &str, cade_args: &[String]) -> String {
         r#"_cade_hook() {
     local previous_exit_status=$?
@@ -224,7 +239,7 @@ impl ShellOutput for Nushell {
             return String::new();
         }
         let mut rec = serde_json::Map::new();
-        rec.insert(key.to_string(), serde_json::Value::from(value));
+        rec.insert(key.to_string(), nushell_env_value(key, value));
         format!("{}\n", serde_json::json!({ "s": rec }))
     }
     fn unset_env(&self, key: &str) -> String {
@@ -236,6 +251,7 @@ impl ShellOutput for Nushell {
     fn emit_hook(&self, command: &str) -> String {
         format!("{}\n", serde_json::json!({ "h": command }))
     }
+
     fn hook_init(&self, cade_exe: &str, cade_args: &[String]) -> String {
         let cade = serde_json::to_string(cade_exe).unwrap_or_else(|_| "\"cade\"".to_string());
         let cade_args = serde_json::to_string(cade_args).unwrap_or_else(|_| "[]".to_string());
@@ -292,6 +308,7 @@ impl ShellOutput for Elvish {
     fn emit_hook(&self, command: &str) -> String {
         format!("{command};")
     }
+
     fn hook_init(&self, cade_exe: &str, cade_args: &[String]) -> String {
         r#"set edit:before-readline = [
     {||
@@ -333,6 +350,7 @@ impl ShellOutput for Murex {
     fn emit_hook(&self, command: &str) -> String {
         format!("{command}\n")
     }
+
     fn hook_init(&self, cade_exe: &str, cade_args: &[String]) -> String {
         // murex runs cade on every prompt (no PWD-change fast-path): its
         // conditional syntax made the guard unreliable
@@ -361,6 +379,11 @@ mod tests {
         assert!(!is_valid_key("x;rm -rf"));
         assert!(!is_valid_key("a=b"));
         assert!(!is_valid_key("a$b"));
+    }
+
+    #[test]
+    fn json_is_not_a_shell_name() {
+        assert!("json".parse::<ShellName>().is_err());
     }
 
     #[test]
@@ -512,5 +535,12 @@ mod tests {
         // a JSON directive parsed with `from json`, never run as nu code
         let v: serde_json::Value = serde_json::from_str(out.trim()).unwrap();
         assert_eq!(v["s"]["X"], "$(id)\"x");
+    }
+
+    #[test]
+    fn nushell_emits_path_as_a_list() {
+        let out = Nushell.set_env("PATH", "/one:/two");
+        let v: serde_json::Value = serde_json::from_str(out.trim()).unwrap();
+        assert_eq!(v["s"]["PATH"], serde_json::json!(["/one", "/two"]));
     }
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,0 +1,80 @@
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+use std::sync::atomic::{AtomicU32, Ordering};
+
+const BIN: &str = env!("CARGO_BIN_EXE_cade");
+
+static COUNTER: AtomicU32 = AtomicU32::new(0);
+
+/// An isolated sandbox: a project tree plus a private cade state directory.
+pub struct Sandbox {
+    pub root: PathBuf,
+    pub state: PathBuf,
+}
+
+impl Sandbox {
+    pub fn new() -> Self {
+        let id = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let base = std::env::temp_dir().join(format!("cade-it-{}-{id}", std::process::id()));
+        let root = base.join("project");
+        let state = base.join("state");
+        std::fs::create_dir_all(&root).unwrap();
+        std::fs::create_dir_all(&state).unwrap();
+        Sandbox { root, state }
+    }
+
+    pub fn write(&self, rel: &str, contents: &str) {
+        let path = self.root.join(rel);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(path, contents).unwrap();
+    }
+
+    pub fn dir(&self, rel: &str) -> PathBuf {
+        let p = self.root.join(rel);
+        std::fs::create_dir_all(&p).unwrap();
+        p
+    }
+
+    /// Write a pre-activation snapshot for `session` (as cade stores it under
+    /// the state dir), so restore tests can simulate an active session.
+    pub fn write_snapshot(&self, session: &str, contents: &str) {
+        let dir = self.state.join("cade").join("snapshots");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join(format!("{session}.env")), contents).unwrap();
+    }
+
+    /// Run `cade <args>` in `cwd` with an isolated, mostly-empty environment.
+    pub fn run(&self, cwd: &Path, args: &[&str], extra_env: &[(&str, &str)]) -> Output {
+        let mut cmd = Command::new(BIN);
+        cmd.args(args)
+            .current_dir(cwd)
+            .env_clear()
+            .env("XDG_STATE_HOME", &self.state)
+            .env("HOME", &self.state);
+        for (k, v) in extra_env {
+            cmd.env(k, v);
+        }
+        cmd.output().expect("run cade")
+    }
+
+    pub fn allow(&self, cwd: &Path) {
+        let out = self.run(cwd, &["allow"], &[]);
+        assert!(out.status.success(), "allow failed: {:?}", out);
+    }
+}
+
+impl Drop for Sandbox {
+    fn drop(&mut self) {
+        if let Some(base) = self.root.parent() {
+            std::fs::remove_dir_all(base).ok();
+        }
+    }
+}
+
+pub fn stdout(out: &Output) -> String {
+    String::from_utf8_lossy(&out.stdout).into_owned()
+}
+
+pub fn stderr(out: &Output) -> String {
+    String::from_utf8_lossy(&out.stderr).into_owned()
+}

--- a/tests/direnv_shim.rs
+++ b/tests/direnv_shim.rs
@@ -1,0 +1,242 @@
+#![cfg(unix)]
+
+use std::fs;
+use std::io::Write;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::time::Duration;
+
+static COUNTER: AtomicU32 = AtomicU32::new(0);
+
+const FAKE_CADE: &str = r#"#!@bash@
+set -u
+
+case "${1:-}" in
+  export)
+    if [ "${2:-}" = "json" ]; then
+      case "${CADE_FAKE_MODE:-ok}" in
+        missing)
+          printf 'no .cade or .envrc found in this directory or any parent\n' >&2
+          exit 7
+          ;;
+        fail)
+          printf 'loader failed\n' >&2
+          exit 42
+          ;;
+        session)
+          printf '{"SESSION":"%s"}\n' "${__CADE_SESSION-unset}"
+          ;;
+        *)
+          printf '{"A":"1"}\n'
+          ;;
+      esac
+    fi
+    ;;
+esac
+"#;
+
+struct ShimSandbox {
+    root: PathBuf,
+    shim: PathBuf,
+}
+
+impl ShimSandbox {
+    fn new() -> Self {
+        let id = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let root = std::env::temp_dir().join(format!("cade-shim-{}-{id}", std::process::id()));
+        fs::create_dir_all(&root).unwrap();
+
+        let bash = bash_path();
+        let bash = bash.to_str().expect("bash path must be valid UTF-8");
+
+        let fake_cade = root.join("cade");
+        write_executable(&fake_cade, &FAKE_CADE.replace("@bash@", bash));
+
+        let template = include_str!("../nix/direnv-compat.bash");
+        let shim = root.join("direnv");
+        write_executable(
+            &shim,
+            &template
+                .replace("#!@bash@/bin/bash", &format!("#!{bash}"))
+                .replace("@cade@", fake_cade.to_str().unwrap()),
+        );
+
+        Self { root, shim }
+    }
+
+    fn run(&self, args: &[&str]) -> Output {
+        self.run_with_mode(args, "ok")
+    }
+
+    fn run_with_mode(&self, args: &[&str], mode: &str) -> Output {
+        let mut command = Command::new(&self.shim);
+        command.args(args).env("CADE_FAKE_MODE", mode);
+        output_with_retry(command)
+    }
+
+    fn run_with_session(&self, args: &[&str], session: &str) -> Output {
+        let mut command = Command::new(&self.shim);
+        command
+            .args(args)
+            .env("CADE_FAKE_MODE", "session")
+            .env("__CADE_SESSION", session);
+        output_with_retry(command)
+    }
+
+    fn run_without_path(&self, args: &[&str]) -> Output {
+        let mut command = Command::new(&self.shim);
+        command.args(args).env_clear().env("CADE_FAKE_MODE", "ok");
+        output_with_retry(command)
+    }
+}
+
+impl Drop for ShimSandbox {
+    fn drop(&mut self) {
+        fs::remove_dir_all(&self.root).ok();
+    }
+}
+
+fn bash_path() -> PathBuf {
+    if let Some(path) = std::env::var_os("BASH").map(PathBuf::from)
+        && path.is_file()
+    {
+        return path;
+    }
+
+    std::env::split_paths(&std::env::var_os("PATH").unwrap_or_default())
+        .map(|dir| dir.join("bash"))
+        .find(|path| path.is_file())
+        .expect("find bash in PATH")
+}
+
+fn make_executable(path: &Path) {
+    let mut permissions = fs::metadata(path).unwrap().permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(path, permissions).unwrap();
+}
+
+fn write_executable(path: &Path, contents: &str) {
+    let mut file = fs::File::create(path).unwrap();
+    file.write_all(contents.as_bytes()).unwrap();
+    file.sync_all().unwrap();
+    drop(file);
+    make_executable(path);
+}
+
+fn output_with_retry(mut command: Command) -> Output {
+    for _ in 0..20 {
+        match command.output() {
+            Ok(output) => return output,
+            Err(err) if err.raw_os_error() == Some(26) => {
+                std::thread::sleep(Duration::from_millis(10));
+            }
+            Err(err) => panic!("run shim: {err}"),
+        }
+    }
+    command.output().expect("run shim")
+}
+
+fn stdout(out: &Output) -> String {
+    String::from_utf8_lossy(&out.stdout).into_owned()
+}
+
+fn stderr(out: &Output) -> String {
+    String::from_utf8_lossy(&out.stderr).into_owned()
+}
+
+#[test]
+fn unsupported_commands_fail() {
+    let sb = ShimSandbox::new();
+    let out = sb.run(&["status"]);
+
+    assert_eq!(out.status.code(), Some(1));
+    assert!(stderr(&out).contains("unsupported command: status"));
+}
+
+#[test]
+fn unsupported_export_targets_fail() {
+    let sb = ShimSandbox::new();
+    let out = sb.run(&["export", "tcsh"]);
+
+    assert_eq!(out.status.code(), Some(1));
+    assert!(stderr(&out).contains("unsupported export target: tcsh"));
+}
+
+#[test]
+fn export_json_delegates_to_cade() {
+    let sb = ShimSandbox::new();
+
+    let out = sb.run(&["export", "json"]);
+    assert!(out.status.success(), "json export failed: {out:?}");
+    assert_eq!(stdout(&out), "{\"A\":\"1\"}\n");
+
+    let out = sb.run_with_mode(&["export", "json"], "fail");
+    assert_eq!(out.status.code(), Some(42));
+    assert!(stderr(&out).contains("loader failed"));
+}
+
+#[test]
+fn export_json_preserves_captured_cade_shell_session() {
+    let sb = ShimSandbox::new();
+
+    let out = sb.run_with_session(&["export", "json"], "active");
+
+    assert!(out.status.success(), "json export failed: {out:?}");
+    assert_eq!(stdout(&out), "{\"SESSION\":\"active\"}\n");
+}
+
+#[test]
+fn export_json_does_not_need_env_on_path() {
+    let sb = ShimSandbox::new();
+
+    let out = sb.run_without_path(&["export", "json"]);
+
+    assert!(out.status.success(), "json export failed: {out:?}");
+    assert_eq!(stdout(&out), "{\"A\":\"1\"}\n");
+}
+
+#[test]
+fn export_json_does_not_interpret_cade_errors() {
+    let sb = ShimSandbox::new();
+
+    let out = sb.run_with_mode(&["export", "json"], "missing");
+
+    assert_eq!(out.status.code(), Some(7));
+    assert!(stdout(&out).is_empty(), "{}", stdout(&out));
+    assert!(stderr(&out).contains("no .cade or .envrc found"));
+}
+
+#[test]
+fn shell_export_is_a_harmless_noop_for_captured_shells() {
+    let sb = ShimSandbox::new();
+
+    let out = sb.run(&["export", "bash"]);
+
+    assert!(out.status.success(), "{out:?}");
+    assert!(stdout(&out).is_empty(), "{}", stdout(&out));
+    assert!(stderr(&out).is_empty(), "{}", stderr(&out));
+}
+
+#[test]
+fn default_export_is_a_harmless_noop_for_captured_shells() {
+    let sb = ShimSandbox::new();
+
+    let out = sb.run(&["export"]);
+
+    assert!(out.status.success(), "{out:?}");
+    assert!(stdout(&out).is_empty(), "{}", stdout(&out));
+    assert!(stderr(&out).is_empty(), "{}", stderr(&out));
+}
+
+#[test]
+fn shell_hook_is_a_harmless_noop_for_captured_shells() {
+    let sb = ShimSandbox::new();
+
+    let out = sb.run(&["hook", "nushell"]);
+
+    assert!(out.status.success(), "{out:?}");
+    assert!(stdout(&out).is_empty(), "{}", stdout(&out));
+    assert!(stderr(&out).is_empty(), "{}", stderr(&out));
+}

--- a/tests/export_json.rs
+++ b/tests/export_json.rs
@@ -1,0 +1,274 @@
+mod common;
+
+use common::{Sandbox, stderr, stdout};
+use std::{path::Path, process::Output};
+
+fn run_export_json(sb: &Sandbox, cwd: &Path, extra_env: &[(&str, &str)]) -> Output {
+    sb.run(cwd, &["export", "json"], extra_env)
+}
+
+fn parse_json(out: &Output) -> serde_json::Value {
+    serde_json::from_str(stdout(out).trim()).unwrap()
+}
+
+fn export_json(sb: &Sandbox, cwd: &Path, extra_env: &[(&str, &str)]) -> serde_json::Value {
+    let out = run_export_json(sb, cwd, extra_env);
+    assert!(out.status.success(), "{out:?}");
+    parse_json(&out)
+}
+
+fn direnv_diff(json: &serde_json::Value) -> String {
+    json["DIRENV_DIFF"]
+        .as_str()
+        .expect("json export should carry direnv state")
+        .to_string()
+}
+
+#[test]
+fn json_export_outside_cade_project_is_empty_diff() {
+    let sb = Sandbox::new();
+    let empty = sb.dir("empty");
+
+    let out = run_export_json(&sb, &empty, &[]);
+
+    assert!(out.status.success(), "{out:?}");
+    assert_eq!(stdout(&out), "{}\n");
+    assert!(stderr(&out).is_empty(), "{}", stderr(&out));
+}
+
+#[test]
+fn json_export_is_not_a_shell_and_has_no_activation_bookkeeping() {
+    let sb = Sandbox::new();
+    sb.write(".cade", "load env\n");
+    sb.write(".env", "A=1\nPATH=/layer\n");
+    sb.allow(&sb.root);
+
+    let bad = sb.run(&sb.root, &["reload", "--shell", "json"], &[]);
+    assert!(!bad.status.success(), "json must not parse as a shell");
+    assert!(
+        stderr(&bad).contains("unknown shell: json"),
+        "{}",
+        stderr(&bad)
+    );
+
+    let out = run_export_json(&sb, &sb.root, &[("PATH", "/usr/bin")]);
+    assert!(out.status.success(), "{out:?}");
+    let v = parse_json(&out);
+    assert_eq!(v["A"], "1");
+    assert_eq!(v["PATH"], "/layer:/usr/bin");
+    assert!(v.get("__CADE_SESSION").is_none(), "{v}");
+    assert!(v.get("__CADE_LAYERS").is_none(), "{v}");
+    assert!(!stderr(&out).contains("cade: loaded"), "{}", stderr(&out));
+}
+
+#[test]
+fn json_export_uses_session_snapshot_for_concat_baseline() {
+    let sb = Sandbox::new();
+    sb.write(".cade", "load env\n");
+    sb.write(".env", "PATH=/layer\n");
+    sb.write_snapshot("active", "PATH=/usr/bin");
+    sb.allow(&sb.root);
+
+    let v = export_json(
+        &sb,
+        &sb.root,
+        &[("__CADE_SESSION", "active"), ("PATH", "/layer:/usr/bin")],
+    );
+    assert_eq!(v["PATH"], "/layer:/usr/bin");
+}
+
+#[test]
+fn json_export_missing_session_snapshot_uses_live_baseline() {
+    let sb = Sandbox::new();
+    sb.write(".cade", "load env\n");
+    sb.write(".env", "PATH=/layer\n");
+    sb.allow(&sb.root);
+
+    let v = export_json(
+        &sb,
+        &sb.root,
+        &[("__CADE_SESSION", "missing"), ("PATH", "/usr/bin")],
+    );
+    assert_eq!(v["PATH"], "/layer:/usr/bin");
+}
+
+#[test]
+fn json_export_reuses_direnv_baseline_without_growing_path() {
+    let sb = Sandbox::new();
+    sb.write(".cade", "load env\n");
+    sb.write(".env", "PATH=/layer\n");
+    sb.allow(&sb.root);
+
+    let first_json = export_json(&sb, &sb.root, &[("PATH", "/usr/bin")]);
+    assert_eq!(first_json["PATH"], "/layer:/usr/bin");
+    let direnv_diff = direnv_diff(&first_json);
+
+    let second_json = export_json(
+        &sb,
+        &sb.root,
+        &[("PATH", "/layer:/usr/bin"), ("DIRENV_DIFF", &direnv_diff)],
+    );
+    assert_eq!(second_json["PATH"], "/layer:/usr/bin");
+}
+
+#[test]
+fn json_export_state_only_stores_changed_key_preimages() {
+    let sb = Sandbox::new();
+    sb.write(".cade", "load env\n");
+    sb.write(".env", "PATH=/layer\nA=1\n");
+    sb.allow(&sb.root);
+
+    let json = export_json(
+        &sb,
+        &sb.root,
+        &[("PATH", "/usr/bin"), ("SECRET", "do-not-store")],
+    );
+    let state: serde_json::Value =
+        serde_json::from_str(json["DIRENV_DIFF"].as_str().unwrap()).unwrap();
+
+    assert_eq!(state["version"], 2);
+    assert_eq!(state["preimage"]["PATH"], "/usr/bin");
+    assert!(state["preimage"].get("A").is_some(), "{state}");
+    assert!(state["preimage"]["A"].is_null(), "{state}");
+    assert!(state["preimage"].get("SECRET").is_none(), "{state}");
+    assert!(state.get("baseline").is_none(), "{state}");
+}
+
+#[test]
+fn json_export_outside_project_restores_previous_direnv_state() {
+    let sb = Sandbox::new();
+    sb.write(".cade", "load env\n");
+    sb.write(".env", "PATH=/layer\n");
+    sb.allow(&sb.root);
+    let outside = sb.state.join("outside");
+    std::fs::create_dir_all(&outside).unwrap();
+
+    let first_json = export_json(&sb, &sb.root, &[("PATH", "/usr/bin")]);
+    let direnv_diff = direnv_diff(&first_json);
+
+    let outside_json = export_json(
+        &sb,
+        &outside,
+        &[("PATH", "/layer:/usr/bin"), ("DIRENV_DIFF", &direnv_diff)],
+    );
+    assert_eq!(outside_json["PATH"], "/usr/bin");
+    assert!(outside_json["DIRENV_DIFF"].is_null(), "{outside_json}");
+}
+
+#[test]
+fn json_export_reenter_after_unload_preserves_baseline_path() {
+    let sb = Sandbox::new();
+    sb.write(".cade", "load env\n");
+    sb.write(".env", "PATH=/layer\n");
+    sb.allow(&sb.root);
+    let outside = sb.state.join("outside-reenter");
+    std::fs::create_dir_all(&outside).unwrap();
+
+    let first_json = export_json(&sb, &sb.root, &[("PATH", "/usr/bin:/bin")]);
+    assert_eq!(first_json["PATH"], "/layer:/usr/bin:/bin");
+    let direnv_diff = direnv_diff(&first_json);
+
+    let outside_json = export_json(
+        &sb,
+        &outside,
+        &[
+            ("PATH", "/layer:/usr/bin:/bin"),
+            ("DIRENV_DIFF", &direnv_diff),
+        ],
+    );
+    assert_eq!(outside_json["PATH"], "/usr/bin:/bin");
+
+    let second_json = export_json(&sb, &sb.root, &[("PATH", "/usr/bin:/bin")]);
+    assert_eq!(second_json["PATH"], "/layer:/usr/bin:/bin");
+}
+
+#[test]
+fn json_export_disallowed_project_restores_previous_direnv_state() {
+    let sb = Sandbox::new();
+    sb.write(".cade", "load env\n");
+    sb.write(".env", "PATH=/layer\n");
+    sb.allow(&sb.root);
+
+    let first_json = export_json(&sb, &sb.root, &[("PATH", "/usr/bin")]);
+    let direnv_diff = direnv_diff(&first_json);
+
+    let disallow = sb.run(&sb.root, &["disallow"], &[]);
+    assert!(disallow.status.success(), "{disallow:?}");
+
+    let second_json = export_json(
+        &sb,
+        &sb.root,
+        &[("PATH", "/layer:/usr/bin"), ("DIRENV_DIFF", &direnv_diff)],
+    );
+    assert_eq!(second_json["PATH"], "/usr/bin");
+    assert!(second_json["DIRENV_DIFF"].is_null(), "{second_json}");
+}
+
+#[test]
+fn json_export_disallowed_project_without_previous_state_fails() {
+    let sb = Sandbox::new();
+    sb.write(".cade", "load env\n");
+    sb.write(".env", "PATH=/layer\n");
+
+    let out = run_export_json(&sb, &sb.root, &[("PATH", "/usr/bin")]);
+
+    assert!(!out.status.success(), "{out:?}");
+    assert!(
+        stderr(&out).contains("run `cade allow`"),
+        "{}",
+        stderr(&out)
+    );
+    assert!(stdout(&out).is_empty(), "{}", stdout(&out));
+}
+
+#[test]
+fn json_export_pure_state_restores_ambient_on_unload() {
+    let sb = Sandbox::new();
+    sb.write(".cade", "pure\nA=1\n");
+    sb.allow(&sb.root);
+    let outside = sb.state.join("outside-pure");
+    std::fs::create_dir_all(&outside).unwrap();
+
+    let first_json = export_json(
+        &sb,
+        &sb.root,
+        &[
+            ("AMBIENT_TEST", "old"),
+            ("PATH", "/usr/bin"),
+            ("HOME", "/home/tester"),
+        ],
+    );
+    assert_eq!(first_json["A"], "1");
+    assert!(first_json["AMBIENT_TEST"].is_null(), "{first_json}");
+    assert!(first_json["PATH"].is_null(), "{first_json}");
+    let first_diff = direnv_diff(&first_json);
+
+    let second_json = export_json(&sb, &sb.root, &[("A", "1"), ("DIRENV_DIFF", &first_diff)]);
+    assert_eq!(second_json["A"], "1");
+    assert!(second_json["AMBIENT_TEST"].is_null(), "{second_json}");
+    assert!(second_json["PATH"].is_null(), "{second_json}");
+    let second_diff = direnv_diff(&second_json);
+
+    let outside_json = export_json(&sb, &outside, &[("A", "1"), ("DIRENV_DIFF", &second_diff)]);
+    assert!(outside_json["A"].is_null(), "{outside_json}");
+    assert_eq!(outside_json["AMBIENT_TEST"], "old");
+    assert_eq!(outside_json["PATH"], "/usr/bin");
+    assert!(outside_json["DIRENV_DIFF"].is_null(), "{outside_json}");
+}
+
+#[test]
+fn json_export_pure_unsets_ambient_without_cade_activation_bookkeeping() {
+    let sb = Sandbox::new();
+    sb.write(".cade", "pure\nA=1\n");
+    sb.allow(&sb.root);
+
+    let v = export_json(
+        &sb,
+        &sb.root,
+        &[("AMBIENT_TEST", "old"), ("HOME", "/home/tester")],
+    );
+    assert_eq!(v["A"], "1");
+    assert!(v["AMBIENT_TEST"].is_null(), "{v}");
+    assert!(v.get("HOME").is_none(), "{v}");
+    assert!(v.get("__CADE_SESSION").is_none(), "{v}");
+}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2,51 +2,12 @@
 //! trees, asserting on the shell statements it emits. Each test gets an
 //! isolated state directory (its own permission/cache DB) via XDG_STATE_HOME.
 
+mod common;
+
+use common::{Sandbox, stderr, stdout};
 use std::path::{Path, PathBuf};
-use std::process::{Command, Output};
-use std::sync::atomic::{AtomicU32, Ordering};
-
-const BIN: &str = env!("CARGO_BIN_EXE_cade");
-
-static COUNTER: AtomicU32 = AtomicU32::new(0);
-
-/// An isolated sandbox: a project tree plus a private cade state directory.
-struct Sandbox {
-    root: PathBuf,
-    state: PathBuf,
-}
 
 impl Sandbox {
-    fn new() -> Self {
-        let id = COUNTER.fetch_add(1, Ordering::Relaxed);
-        let base = std::env::temp_dir().join(format!("cade-it-{}-{}", std::process::id(), id));
-        let root = base.join("project");
-        let state = base.join("state");
-        std::fs::create_dir_all(&root).unwrap();
-        std::fs::create_dir_all(&state).unwrap();
-        Sandbox { root, state }
-    }
-
-    fn write(&self, rel: &str, contents: &str) {
-        let path = self.root.join(rel);
-        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
-        std::fs::write(path, contents).unwrap();
-    }
-
-    fn dir(&self, rel: &str) -> PathBuf {
-        let p = self.root.join(rel);
-        std::fs::create_dir_all(&p).unwrap();
-        p
-    }
-
-    /// Write a pre-activation snapshot for `session` (as cade stores it under
-    /// the state dir), so restore tests can simulate an active session.
-    fn write_snapshot(&self, session: &str, contents: &str) {
-        let dir = self.state.join("cade").join("snapshots");
-        std::fs::create_dir_all(&dir).unwrap();
-        std::fs::write(dir.join(format!("{session}.env")), contents).unwrap();
-    }
-
     fn write_config(&self, contents: &str) -> PathBuf {
         let path = self.state.join(".config").join("cade").join("config.toml");
         std::fs::create_dir_all(path.parent().unwrap()).unwrap();
@@ -62,40 +23,9 @@ impl Sandbox {
         (home, path)
     }
 
-    /// Run `cade <args>` in `cwd` with an isolated, mostly-empty environment.
-    fn run(&self, cwd: &Path, args: &[&str], extra_env: &[(&str, &str)]) -> Output {
-        let mut cmd = Command::new(BIN);
-        cmd.args(args)
-            .current_dir(cwd)
-            .env_clear()
-            .env("XDG_STATE_HOME", &self.state)
-            .env("HOME", &self.state);
-        for (k, v) in extra_env {
-            cmd.env(k, v);
-        }
-        cmd.output().expect("run cade")
-    }
-
-    fn allow(&self, cwd: &Path) {
-        let out = self.run(cwd, &["allow"], &[]);
-        assert!(out.status.success(), "allow failed: {:?}", out);
-    }
-
-    fn enter(&self, cwd: &Path, extra_env: &[(&str, &str)]) -> Output {
+    fn enter(&self, cwd: &Path, extra_env: &[(&str, &str)]) -> std::process::Output {
         self.run(cwd, &["enter", "--shell", "bash"], extra_env)
     }
-}
-
-impl Drop for Sandbox {
-    fn drop(&mut self) {
-        if let Some(base) = self.root.parent() {
-            std::fs::remove_dir_all(base).ok();
-        }
-    }
-}
-
-fn stdout(out: &Output) -> String {
-    String::from_utf8_lossy(&out.stdout).into_owned()
 }
 
 #[test]
@@ -586,10 +516,6 @@ fn cache_invalidates_when_env_file_changes() {
         "cache served a stale value: {}",
         stdout(&second)
     );
-}
-
-fn stderr(out: &Output) -> String {
-    String::from_utf8_lossy(&out.stderr).into_owned()
 }
 
 #[test]
@@ -1196,7 +1122,7 @@ fn envrc_is_autodetected_when_no_cade() {
 
     sb.allow(&sb.root);
     let out = sb.enter(&sb.root, &[]);
-    assert!(out.status.success(), "envrc activation failed: {:?}", out);
+    assert!(out.status.success(), "envrc activation failed: {out:?}");
     assert!(
         stdout(&out).contains("export FROM_ENVRC='1';"),
         "{}",
@@ -1213,7 +1139,7 @@ fn explicit_load_envrc_directive() {
 
     sb.allow(&sb.root);
     let out = sb.enter(&sb.root, &[]);
-    assert!(out.status.success(), "{:?}", out);
+    assert!(out.status.success(), "{out:?}");
     assert!(stdout(&out).contains("export FROM_DIRECTIVE='yes';"));
 }
 
@@ -1224,7 +1150,7 @@ fn envrc_literal_export_and_path_add() {
     sb.allow(&sb.root);
 
     let out = sb.enter(&sb.root, &[]);
-    assert!(out.status.success(), "{:?}", out);
+    assert!(out.status.success(), "{out:?}");
     let s = stdout(&out);
     assert!(s.contains("export PLAIN='ok';"), "{s}");
     // PATH_add prepends a dir resolved against the .envrc location
@@ -1239,11 +1165,7 @@ fn envrc_unsupported_lines_warn_and_are_skipped() {
     sb.allow(&sb.root);
 
     let out = sb.enter(&sb.root, &[]);
-    assert!(
-        out.status.success(),
-        "warn-and-continue, not fail: {:?}",
-        out
-    );
+    assert!(out.status.success(), "warn-and-continue, not fail: {out:?}");
     let s = stdout(&out);
     assert!(s.contains("export GOOD='fine';"), "good line dropped: {s}");
     assert!(


### PR DESCRIPTION
successor of #7.

This PR implements cade-backed direnv compatibility:

- Add `cade export json`, producing a direnv-compatible JSON env delta.
- Add a packaged `direnv` shim:
  - `direnv export json` -> `cade export json`
  - shell exports/hooks/allow/deny/status mapped to cade equivalents
- Add Nix flake/package/module wiring:
  - `.#direnv-compat`
  - `.#direnv-compat-bash`
  - `programs.cade.direnvCompat = true`
- Rework Nix shell loading to use `nix develop --command ... env -0` instead of `nix print-dev-env --json`, so `shellHook` mutations like `PATH` changes are captured.
- Add `src/env_delta.rs` to centralize env diff rendering for shell output and JSON export.
- Split shell rendering into `EnvOutput` vs `ShellOutput`, and emits Nushell `PATH` as a list.
- Split tests into focused files for direnv shim, envrc integration, JSON export, and shared test helpers.
- Keep main’s newer slow-loader progress output while merging in the Nix env capture logic.