### PR TITLE
various: fix newline spam on load

### DIFF
--- a/src/loaders.rs
+++ b/src/loaders.rs
@@ -190,7 +190,7 @@ impl<'a> LongRunningProgress<'a> {
         }
         eprint!("\x1b[{}F", self.visible_lines);
         for _ in 0..self.visible_lines {
-            eprintln!("\x1b[2K");
+            write!(&mut std::io::stderr(), "\x1b[2K\x1b[1B").ok();
         }
         eprint!("\x1b[{}F", self.visible_lines);
         let _ = std::io::stderr().flush();

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -64,13 +64,14 @@ impl State {
 }
 
 /// Move the cursor back to the top of a `n`-line block, clearing it on the way.
+/// Avoid `writeln!`/`eprintln!` so stray `\n` won't produce visible scrollback.
 fn rewind(err: &mut impl Write, n: usize) {
     if n == 0 {
         return;
     }
     let _ = write!(err, "\x1b[{n}F");
     for _ in 0..n {
-        let _ = writeln!(err, "\x1b[2K");
+        let _ = write!(err, "\x1b[2K\x1b[1B");
     }
     let _ = write!(err, "\x1b[{n}F");
 }


### PR DESCRIPTION
It doesn't happen every time and I wasn't able to figure out exactly why it did. However, it is fixed by this change. Now the status updates re-use the same line which I assume is the intention.

Before (shortened but it was about twice this length):
```
p[\] cade: nix develop at /home/jam/projects/grove-3 is taking a long time; 
p[-] cade: nix develop at /home/jam/projects/grove-3 is taking a long time; 
p[/] cade: nix develop at /home/jam/projects/grove-3 is taking a long time; 
p[|] cade: nix develop at /home/jam/projects/grove-3 is taking a long time; 
p[\] cade: nix develop at /home/jam/projects/grove-3 is taking a long time; 
p[-] cade: nix develop at /home/jam/projects/grove-3 is taking a long time; 
p[/] cade: nix develop at /home/jam/projects/grove-3 is taking a long time; 
p[|] cade: nix develop at /home/jam/projects/grove-3 is taking a long time; 
p[\] cade: nix develop at /home/jam/projects/grove-3 is taking a long time; 
p[-] cade: nix develop at /home/jam/projects/grove-3 is taking a long time; 
p[/] cade: nix develop at /home/jam/projects/grove-3 is taking a long time; 
p[|] cade: nix develop at /home/jam/projects/grove-3 is taking a long time; press Ctrl-C to stop and inspect the command.
```

After:
```
cade is now allowed in /home/jam/projects/grove-3.
[→] cade: loaded /home/jam/projects/grove-3.
grove root loaded!
```